### PR TITLE
fix: prevent exam errors from displaying off exam page

### DIFF
--- a/src/exam/Exam.jsx
+++ b/src/exam/Exam.jsx
@@ -94,7 +94,9 @@ const Exam = ({
           pingAttempt={pingAttempt}
         />
       )}
-      {apiErrorMsg && <ExamAPIError />}
+      { // show the error message only if you are in the exam sequence
+        isTimeLimited && apiErrorMsg && <ExamAPIError />
+      }
       {isTimeLimited && !originalUserIsStaff && !isGated
         ? <Instructions>{sequenceContent}</Instructions>
         : sequenceContent}

--- a/src/exam/ExamWrapper.test.jsx
+++ b/src/exam/ExamWrapper.test.jsx
@@ -95,6 +95,25 @@ describe('SequenceExamWrapper', () => {
     expect(queryByTestId('exam-api-error-component')).toBeInTheDocument();
   });
 
+  it('does not show exam api error component on a non-exam sequence', () => {
+    store.getState = () => ({
+      examState: Factory.build('examState', {
+        apiErrorMsg: 'Something bad has happened.',
+      }),
+    });
+
+    const { queryByTestId } = render(
+      <ExamStateProvider>
+        <SequenceExamWrapper sequence={{ ...sequence, isTimeLimited: false }} courseId={courseId}>
+          <div>children</div>
+        </SequenceExamWrapper>
+      </ExamStateProvider>,
+      { store },
+    );
+    expect(queryByTestId('exam-instructions-title')).not.toBeInTheDocument();
+    expect(queryByTestId('exam-api-error-component')).not.toBeInTheDocument();
+  });
+
   it('does not take any actions if sequence item is not exam', () => {
     const { getByTestId } = render(
       <ExamStateProvider>


### PR DESCRIPTION
https://openedx.atlassian.net/browse/MST-905

Since we make an exam attempt call on every sequence to show the exam bar if people have navigated away from it, we run the risk of 403 or other transient problem in the exam call on every page. That then shows an error which makes no sense when the user is not taking an exam.

Since the errors are still critical when you are working on the exam and if the call fails we don't know if you have a current exam, we've decided to suppress these errors if you are not currently looking at the exam itself. For most pages this prevents spurious errors. 

If you are in an exam and navigate away from it and then have an error that will also be suppressed, but you will recover from transient errors on the next page and get the exam bar back.

Tested locally by intercepting the proctored exam attempt API call and turning the return into a 403 or 404. These are still visible in the error bar on the exam page itself, but suppressed on other pages.