### PR TITLE
feat: fetch exam access token

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,16 @@
+import { examRequiresAccessToken, store } from './data';
+
+export function isExam() {
+  const { exam } = store.getState().examState;
+  return exam.id !== null;
+}
+
+export function getExamAccess() {
+  const { examAccessToken } = store.getState().examState;
+  return examAccessToken.exam_access_token;
+}
+
+export async function fetchExamAccess() {
+  const { dispatch } = store;
+  return dispatch(examRequiresAccessToken());
+}

--- a/src/data/__factories__/examAccessToken.factory.js
+++ b/src/data/__factories__/examAccessToken.factory.js
@@ -1,0 +1,7 @@
+import { Factory } from 'rosie'; // eslint-disable-line import/no-extraneous-dependencies
+
+Factory.define('examAccessToken')
+  .attrs({
+    exam_access_token: 'Z173480948902JK34432',
+    exam_access_token_expiration: '60',
+  });

--- a/src/data/__factories__/examState.factory.js
+++ b/src/data/__factories__/examState.factory.js
@@ -2,10 +2,12 @@ import { Factory } from 'rosie'; // eslint-disable-line import/no-extraneous-dep
 
 import './exam.factory';
 import './proctoringSettings.factory';
+import './examAccessToken.factory';
 
 Factory.define('examState')
   .attr('proctoringSettings', Factory.build('proctoringSettings'))
   .attr('exam', Factory.build('exam'))
+  .attr('examAccessToken', Factory.build('examAccessToken'))
   .attrs({
     isLoading: false,
     activeAttempt: null,

--- a/src/data/__factories__/index.js
+++ b/src/data/__factories__/index.js
@@ -2,3 +2,4 @@ import './examState.factory';
 import './exam.factory';
 import './attempt.factory';
 import './proctoringSettings.factory';
+import './examAccessToken.factory';

--- a/src/data/__snapshots__/redux.test.jsx.snap
+++ b/src/data/__snapshots__/redux.test.jsx.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Data layer integration tests Test examRequiresAccessToken for exams IDA url Should get exam access token 1`] = `
+Object {
+  "exam_access_token": "Z173480948902JK34432",
+  "exam_access_token_expiration": "60",
+}
+`;
+
 exports[`Data layer integration tests Test exams IDA url Should call the exams service to fetch attempt data 1`] = `
 Object {
   "examState": Object {
@@ -62,6 +69,10 @@ Object {
       "total_time": "30 minutes",
       "type": "timed",
     },
+    "examAccessToken": Object {
+      "exam_access_token": "",
+      "exam_access_token_expiration": "",
+    },
     "isLoading": false,
     "proctoringSettings": Object {
       "contact_us": "",
@@ -107,6 +118,10 @@ Object {
     "allowProctoringOptOut": false,
     "apiErrorMsg": "",
     "exam": Object {},
+    "examAccessToken": Object {
+      "exam_access_token": "",
+      "exam_access_token_expiration": "",
+    },
     "isLoading": false,
     "proctoringSettings": Object {
       "contact_us": "",
@@ -191,6 +206,10 @@ Object {
       "total_time": "30 minutes",
       "type": "timed",
     },
+    "examAccessToken": Object {
+      "exam_access_token": "",
+      "exam_access_token_expiration": "",
+    },
     "isLoading": false,
     "proctoringSettings": Object {
       "contact_us": "",
@@ -236,6 +255,10 @@ Object {
     "allowProctoringOptOut": false,
     "apiErrorMsg": "",
     "exam": Object {},
+    "examAccessToken": Object {
+      "exam_access_token": "",
+      "exam_access_token_expiration": "",
+    },
     "isLoading": false,
     "proctoringSettings": Object {
       "contact_us": "",
@@ -386,6 +409,10 @@ Object {
       "time_limit_mins": 30,
       "total_time": "30 minutes",
       "type": "timed",
+    },
+    "examAccessToken": Object {
+      "exam_access_token": "",
+      "exam_access_token_expiration": "",
     },
     "isLoading": false,
     "proctoringSettings": Object {

--- a/src/data/api.js
+++ b/src/data/api.js
@@ -144,3 +144,11 @@ export async function fetchProctoringSettings(examId) {
   const { data } = await getAuthenticatedHttpClient().get(url.href);
   return data;
 }
+
+export async function fetchExamAccessToken(examId) {
+  const url = new URL(
+    `${getConfig().EXAMS_BASE_URL}/api/v1/access_tokens/exam_id/${examId}/`,
+  );
+  const { data } = await getAuthenticatedHttpClient().get(url.href);
+  return data;
+}

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -14,6 +14,7 @@ export {
   pingAttempt,
   resetExam,
   getAllowProctoringOptOut,
+  examRequiresAccessToken,
 } from './thunks';
 
 export { default as store } from './store';

--- a/src/data/slice.js
+++ b/src/data/slice.js
@@ -64,6 +64,10 @@ export const examSlice = createSlice({
       type: '',
     },
     apiErrorMsg: '',
+    examAccessToken: {
+      exam_access_token: '',
+      exam_access_token_expiration: '',
+    },
   },
   reducers: {
     setAllowProctoringOptOut: (state, { payload }) => {
@@ -83,6 +87,9 @@ export const examSlice = createSlice({
     setProctoringSettings: (state, { payload }) => {
       state.proctoringSettings = payload.proctoringSettings;
     },
+    setExamAccessToken: (state, { payload }) => {
+      state.examAccessToken = payload.examAccessToken;
+    },
     expireExamAttempt: (state) => {
       state.timeIsOver = true;
     },
@@ -97,8 +104,8 @@ export const examSlice = createSlice({
 
 export const {
   setIsLoading, setExamState, expireExamAttempt,
-  setActiveAttempt, setProctoringSettings, setReviewPolicy,
-  setApiError, setAllowProctoringOptOut,
+  setActiveAttempt, setProctoringSettings, setExamAccessToken,
+  setReviewPolicy, setApiError, setAllowProctoringOptOut,
 } = examSlice.actions;
 
 export default examSlice.reducer;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,2 +1,8 @@
 export { default } from './core/SequenceExamWrapper';
 export { default as OuterExamTimer } from './core/OuterExamTimer';
+export {
+  getExamAccess,
+  isExam,
+  fetchExamAccess,
+} from './api';
+export { store } from './data';


### PR DESCRIPTION
From the Jira ticket, [MST-1599](https://2u-internal.atlassian.net/browse/MST-1599): 

> Before the frontend-lib-special-exams can render any content within an exam, it should first fetch an access ticket. The access ticket will eventually be passed down to the xblock via cookie, but this ticket should only involve making a call to get the access ticket.
> 
> Prior to rendering any content (aka blocking rendering), the exams library should make a request to the get exam access ticket endpoint, and the endpoint will create a ticket and set it as a cookie. 