### PR TITLE
fix: i18n fixes and prep to push to Transifex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ i18n.extract:
 
 i18n.concat:
 	# Gathering JSON messages into one file...
+	mkdir -p $(i18n)
 	$(transifex_utils) $(transifex_temp) $(transifex_input)
 
 extract_translations: | requirements i18n.extract i18n.concat

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,9 +1,0 @@
-module.exports = {
-  presets: [
-    [
-      '@babel/preset-env',
-      { targets: { browsers: ['last 2 versions', 'safari >= 7'] } },
-    ],
-    '@babel/preset-react',
-  ],
-};

--- a/src/instructions/proctored_exam/SkipProctoredExamInstruction.jsx
+++ b/src/instructions/proctored_exam/SkipProctoredExamInstruction.jsx
@@ -20,7 +20,7 @@ const SkipProctoredExamInstruction = ({ cancelSkipProctoredExam }) => {
         </p>
         <p>
           <FormattedMessage
-            id="exam.skipProctoredExamInstructions.text1"
+            id="exam.skipProctoredExamInstructions.text2"
             defaultMessage={'If you take this exam without proctoring, you will not be eligible for '
             + 'course credit or the MicroMasters credential if either applies to this course.'}
           />

--- a/src/timer/ExamTimerBlock.jsx
+++ b/src/timer/ExamTimerBlock.jsx
@@ -66,16 +66,17 @@ const ExamTimerBlock = injectIntl(({
           <div>
             <FormattedMessage
               id="exam.examTimer.text"
-              defaultMessage='You are taking "'
+              defaultMessage='You are taking "{examLink}" as {examType}.'
+              values={{
+                examLink: (
+                  <Alert.Link href={attempt.exam_url_path}>
+                    {attempt.exam_display_name}
+                  </Alert.Link>
+                ),
+                examType: attempt.exam_type,
+              }}
             />
-            <Alert.Link href={attempt.exam_url_path}>
-              {attempt.exam_display_name}
-            </Alert.Link>
-            <FormattedMessage
-              id="exam.examTimer.text"
-              defaultMessage='" as {examType}. '
-              values={{ examType: attempt.exam_type }}
-            />
+            {' '}
             {
               isShowMore
                 ? (


### PR DESCRIPTION
Multiple related changes:

 - Fixed missing i18n directory when running `make extract_translations`
 - Fixed jsx duplicate FormattedMessage IDs
 - Refactored exam.examTimer.text into a single message instead of concatination
 - Removed babel.config.js to fix missing i18n plugin which causes "No messages found" error

Refs: FC-0012 OEP-58


### TODO 
 - [x] Test the `exam.examTimer.text` message in the ~browser~ terminal
 - [x] Test the pull in integration with `openedx-translations`: https://github.com/Zeit-Labs/openedx-translations/actions/runs/4428893618/jobs/7768625210