### PR TITLE
feat: send attempt id on exam ping/end messages

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ module.exports = createConfig('jest', {
     '<rootDir>/src/setupTest.js',
   ],
   coveragePathIgnorePatterns: [
+    'src/data/messages/handlers.js',
     'src/setupTest.js',
     'src/i18n',
   ],

--- a/src/data/messages/handlers.js
+++ b/src/data/messages/handlers.js
@@ -34,11 +34,11 @@ export function workerPromiseForEventNames(eventNames, workerUrl) {
   };
 }
 
-export function pingApplication(timeoutInSeconds, workerUrl) {
+export function pingApplication(timeoutInSeconds, attemptExternalId, workerUrl) {
   const TIMEOUT_BUFFER_SECONDS = 10;
   const workerPingTimeout = timeoutInSeconds - TIMEOUT_BUFFER_SECONDS; // 10s buffer for worker to respond
   return Promise.race([
-    workerPromiseForEventNames(actionToMessageTypesMap.ping, workerUrl)(workerPingTimeout * 1000),
+    workerPromiseForEventNames(actionToMessageTypesMap.ping, workerUrl)(workerPingTimeout * 1000, attemptExternalId),
     workerTimeoutPromise(timeoutInSeconds * 1000),
   ]);
 }


### PR DESCRIPTION
### [MST-1802](https://2u-internal.atlassian.net/browse/MST-1802)

Update frontend-lib to go along with https://github.com/openedx/edx-proctoring/pull/1106

edit: added an ignore to coverage to handlers.js since we don't have anything scaffolded out to test this.