### PR TITLE
feat: call edx-exams if exams base url is defined

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,2 +1,3 @@
 LANGUAGE_PREFERENCE_COOKIE_NAME='openedx-language-preference'
 LMS_BASE_URL='http://localhost:18000'
+EXAMS_BASE_URL='http://localhost:18740'

--- a/src/data/api.js
+++ b/src/data/api.js
@@ -22,7 +22,13 @@ export async function pollExamAttempt(url) {
 }
 
 export async function createExamAttempt(examId, startClock = true, attemptProctored = false) {
-  const url = new URL(`${getConfig().LMS_BASE_URL}${BASE_API_URL}`);
+  let urlString;
+  if (!getConfig().EXAMS_BASE_URL) {
+    urlString = `${getConfig().LMS_BASE_URL}${BASE_API_URL}`;
+  } else {
+    urlString = `${getConfig().EXAMS_BASE_URL}/exams/attempt`;
+  }
+  const url = new URL(urlString);
   const payload = {
     exam_id: examId,
     start_clock: startClock.toString(),
@@ -33,7 +39,13 @@ export async function createExamAttempt(examId, startClock = true, attemptProcto
 }
 
 export async function updateAttemptStatus(attemptId, action, detail = null) {
-  const url = new URL(`${getConfig().LMS_BASE_URL}${BASE_API_URL}/${attemptId}`);
+  let urlString;
+  if (!getConfig().EXAMS_BASE_URL) {
+    urlString = `${getConfig().LMS_BASE_URL}${BASE_API_URL}/${attemptId}`;
+  } else {
+    urlString = `${getConfig().EXAMS_BASE_URL}/attempt/${attemptId}`;
+  }
+  const url = new URL(urlString);
   const payload = { action };
   if (detail) {
     payload.detail = detail;


### PR DESCRIPTION
## [MST-1643](https://2u-internal.atlassian.net/browse/MST-1643)

If the exams service is configured, we should call `edx-exams` endpoints instead of `edx-proctoring`.