### PR TITLE
route attempt endpoints to correct backend

### DIFF
--- a/src/api.test.jsx
+++ b/src/api.test.jsx
@@ -1,0 +1,26 @@
+import { isExam, getExamAccess, fetchExamAccess } from './api';
+
+describe('External API integration tests', () => {
+  let store;
+
+  describe('Test isExam', () => {
+    it('Should return false if exam is not set', async () => {
+      expect(isExam()).toBe(false);
+    });
+  });
+
+  describe('Test getExamAccess', () => {
+    it('Should return empty string if no access token', async () => {
+      expect(getExamAccess()).toBe('');
+    });
+  });
+
+  describe('Test fetchExamAccess', () => {
+    it('Should dispatch get exam access token', async () => {
+      const mockDispatch = jest.fn(() => store.dispatch);
+      const mockState = jest.fn(() => store.getState);
+      const dispatchReturn = fetchExamAccess(mockDispatch, mockState);
+      expect(dispatchReturn).toBeInstanceOf(Promise);
+    });
+  });
+});

--- a/src/data/__snapshots__/redux.test.jsx.snap
+++ b/src/data/__snapshots__/redux.test.jsx.snap
@@ -7,134 +7,6 @@ Object {
 }
 `;
 
-exports[`Data layer integration tests Test exams IDA url Should call the exams service to fetch attempt data 1`] = `
-Object {
-  "examState": Object {
-    "activeAttempt": Object {
-      "attempt_code": "",
-      "attempt_id": 1,
-      "attempt_status": "started",
-      "course_id": "course-v1:test+special+exam",
-      "desktop_application_js_url": "",
-      "exam_display_name": "timed",
-      "exam_started_poll_url": "/api/edx_proctoring/v1/proctored_exam/attempt/1",
-      "exam_type": "a timed exam",
-      "exam_url_path": "http://localhost:2000/course/course-v1:test+special+exam/block-v1:test+special+exam+type@sequential+block@abc123",
-      "in_timed_exam": true,
-      "software_download_url": "",
-      "taking_as_proctored": false,
-      "time_remaining_seconds": 1799.9,
-      "total_time": "30 minutes",
-    },
-    "allowProctoringOptOut": false,
-    "apiErrorMsg": "",
-    "exam": Object {
-      "attempt": Object {
-        "attempt_code": "",
-        "attempt_id": 1,
-        "attempt_status": "started",
-        "course_id": "course-v1:test+special+exam",
-        "desktop_application_js_url": "",
-        "exam_display_name": "timed",
-        "exam_started_poll_url": "/api/edx_proctoring/v1/proctored_exam/attempt/1",
-        "exam_type": "a timed exam",
-        "exam_url_path": "http://localhost:2000/course/course-v1:test+special+exam/block-v1:test+special+exam+type@sequential+block@abc123",
-        "in_timed_exam": true,
-        "software_download_url": "",
-        "taking_as_proctored": false,
-        "time_remaining_seconds": 1799.9,
-        "total_time": "30 minutes",
-      },
-      "backend": "test",
-      "content_id": "block-v1:test+special+exam+type@sequential+block@abc123",
-      "course_id": "course-v1:test+special+exam",
-      "due_date": null,
-      "exam_name": "prock exam",
-      "external_id": null,
-      "hide_after_due": false,
-      "id": 1,
-      "is_active": true,
-      "is_practice_exam": false,
-      "is_proctored": false,
-      "prerequisite_status": Object {
-        "are_prerequisites_satisifed": true,
-        "declined_prerequisites": Array [],
-        "failed_prerequisites": Array [],
-        "pending_prerequisites": Array [],
-        "satisfied_prerequisites": Array [],
-      },
-      "time_limit_mins": 30,
-      "total_time": "30 minutes",
-      "type": "timed",
-    },
-    "examAccessToken": Object {
-      "exam_access_token": "",
-      "exam_access_token_expiration": "",
-    },
-    "isLoading": false,
-    "proctoringSettings": Object {
-      "exam_proctoring_backend": Object {
-        "download_url": "",
-        "instructions": Array [],
-        "name": "",
-        "rules": Object {},
-      },
-      "integration_specific_email": "",
-      "learner_notification_from_email": "",
-      "provider_name": "",
-      "provider_tech_support_email": "",
-      "provider_tech_support_phone": "",
-    },
-    "timeIsOver": false,
-  },
-}
-`;
-
-exports[`Data layer integration tests Test exams IDA url Should call the exams service to get latest attempt data 1`] = `
-Object {
-  "examState": Object {
-    "activeAttempt": Object {
-      "attempt_code": "",
-      "attempt_id": 1,
-      "attempt_status": "ready_to_submit",
-      "course_id": "course-v1:test+special+exam",
-      "desktop_application_js_url": "",
-      "exam_display_name": "timed",
-      "exam_started_poll_url": "/api/edx_proctoring/v1/proctored_exam/attempt/1",
-      "exam_type": "a timed exam",
-      "exam_url_path": "http://localhost:2000/course/course-v1:test+special+exam/block-v1:test+special+exam+type@sequential+block@abc123",
-      "in_timed_exam": true,
-      "software_download_url": "",
-      "taking_as_proctored": false,
-      "time_remaining_seconds": 1799.9,
-      "total_time": "30 minutes",
-    },
-    "allowProctoringOptOut": false,
-    "apiErrorMsg": "",
-    "exam": Object {},
-    "examAccessToken": Object {
-      "exam_access_token": "",
-      "exam_access_token_expiration": "",
-    },
-    "isLoading": false,
-    "proctoringSettings": Object {
-      "exam_proctoring_backend": Object {
-        "download_url": "",
-        "instructions": Array [],
-        "name": "",
-        "rules": Object {},
-      },
-      "integration_specific_email": "",
-      "learner_notification_from_email": "",
-      "provider_name": "",
-      "provider_tech_support_email": "",
-      "provider_tech_support_phone": "",
-    },
-    "timeIsOver": false,
-  },
-}
-`;
-
 exports[`Data layer integration tests Test getExamAttemptsData Should get, and save exam and attempt 1`] = `
 Object {
   "examState": Object {
@@ -218,56 +90,10 @@ Object {
 }
 `;
 
-exports[`Data layer integration tests Test getLatestAttemptData Should get, and save latest attempt 1`] = `
-Object {
-  "examState": Object {
-    "activeAttempt": Object {
-      "attempt_code": "",
-      "attempt_id": 1,
-      "attempt_status": "started",
-      "course_id": "course-v1:test+special+exam",
-      "desktop_application_js_url": "",
-      "exam_display_name": "timed",
-      "exam_started_poll_url": "/api/edx_proctoring/v1/proctored_exam/attempt/1",
-      "exam_type": "a timed exam",
-      "exam_url_path": "http://localhost:2000/course/course-v1:test+special+exam/block-v1:test+special+exam+type@sequential+block@abc123",
-      "in_timed_exam": true,
-      "software_download_url": "",
-      "taking_as_proctored": false,
-      "time_remaining_seconds": 1799.9,
-      "total_time": "30 minutes",
-    },
-    "allowProctoringOptOut": false,
-    "apiErrorMsg": "",
-    "exam": Object {},
-    "examAccessToken": Object {
-      "exam_access_token": "",
-      "exam_access_token_expiration": "",
-    },
-    "isLoading": false,
-    "proctoringSettings": Object {
-      "exam_proctoring_backend": Object {
-        "download_url": "",
-        "instructions": Array [],
-        "name": "",
-        "rules": Object {},
-      },
-      "integration_specific_email": "",
-      "learner_notification_from_email": "",
-      "provider_name": "",
-      "provider_tech_support_email": "",
-      "provider_tech_support_phone": "",
-    },
-    "timeIsOver": false,
-  },
-}
-`;
-
 exports[`Data layer integration tests Test getLatestAttemptData with edx-proctoring as a backend (no EXAMS_BASE_URL) Should get, and save latest attempt 1`] = `
 Object {
   "examState": Object {
     "activeAttempt": Object {
-      "accessibility_time_string": "you have 30 minutes remaining",
       "attempt_code": "",
       "attempt_id": 1,
       "attempt_status": "started",
@@ -292,7 +118,6 @@ Object {
     },
     "isLoading": false,
     "proctoringSettings": Object {
-      "contact_us": "",
       "exam_proctoring_backend": Object {
         "download_url": "",
         "instructions": Array [],
@@ -301,8 +126,6 @@ Object {
       },
       "integration_specific_email": "",
       "learner_notification_from_email": "",
-      "link_urls": null,
-      "platform_name": "",
       "provider_name": "",
       "provider_tech_support_email": "",
       "provider_tech_support_phone": "",
@@ -346,7 +169,6 @@ Object {
 
 exports[`Data layer integration tests Test pollAttempt Should poll and update active attempt 1`] = `
 Object {
-  "accessibility_time_string": "you have 29 minutes remaining",
   "attempt_code": "",
   "attempt_id": 1,
   "attempt_status": "started",
@@ -410,7 +232,6 @@ Object {
     "apiErrorMsg": "",
     "exam": Object {
       "attempt": Object {
-        "accessibility_time_string": "you have 30 minutes remaining",
         "attempt_code": "",
         "attempt_id": 2,
         "attempt_status": "created",
@@ -454,7 +275,6 @@ Object {
     },
     "isLoading": false,
     "proctoringSettings": Object {
-      "contact_us": "",
       "exam_proctoring_backend": Object {
         "download_url": "",
         "instructions": Array [],
@@ -463,8 +283,6 @@ Object {
       },
       "integration_specific_email": "",
       "learner_notification_from_email": "",
-      "link_urls": null,
-      "platform_name": "",
       "provider_name": "",
       "provider_tech_support_email": "",
       "provider_tech_support_phone": "",
@@ -563,7 +381,6 @@ Object {
 
 exports[`Data layer integration tests Test startProctoredExam with edx-proctoring as a backend (no EXAMS_BASE_URL) Should start exam, and update attempt and exam 1`] = `
 Object {
-  "accessibility_time_string": "you have 30 minutes remaining",
   "attempt_code": "",
   "attempt_id": 1,
   "attempt_status": "started",
@@ -581,7 +398,7 @@ Object {
 }
 `;
 
-exports[`Data layer integration tests Test startTimedExam Should start exam, and update attempt and exam 1`] = `
+exports[`Data layer integration tests Test startTimedExam Should create and start exam 1`] = `
 Object {
   "attempt_code": "",
   "attempt_id": 1,
@@ -600,9 +417,8 @@ Object {
 }
 `;
 
-exports[`Data layer integration tests Test startTimedExam with edx-proctoring as a backend (no EXAMS_BASE_URL) Should start exam, and update attempt and exam 1`] = `
+exports[`Data layer integration tests Test startTimedExam with edx-proctoring as a backend (no EXAMS_BASE_URL) Should create and start exam 1`] = `
 Object {
-  "accessibility_time_string": "you have 30 minutes remaining",
   "attempt_code": "",
   "attempt_id": 1,
   "attempt_status": "started",

--- a/src/data/__snapshots__/redux.test.jsx.snap
+++ b/src/data/__snapshots__/redux.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Data layer integration tests Test examRequiresAccessToken for exams IDA url Should get exam access token 1`] = `
+exports[`Data layer integration tests Test examRequiresAccessToken Should get exam access token 1`] = `
 Object {
   "exam_access_token": "Z173480948902JK34432",
   "exam_access_token_expiration": "60",
@@ -263,6 +263,55 @@ Object {
 }
 `;
 
+exports[`Data layer integration tests Test getLatestAttemptData with edx-proctoring as a backend (no EXAMS_BASE_URL) Should get, and save latest attempt 1`] = `
+Object {
+  "examState": Object {
+    "activeAttempt": Object {
+      "accessibility_time_string": "you have 30 minutes remaining",
+      "attempt_code": "",
+      "attempt_id": 1,
+      "attempt_status": "started",
+      "course_id": "course-v1:test+special+exam",
+      "desktop_application_js_url": "",
+      "exam_display_name": "timed",
+      "exam_started_poll_url": "/api/edx_proctoring/v1/proctored_exam/attempt/1",
+      "exam_type": "a timed exam",
+      "exam_url_path": "http://localhost:2000/course/course-v1:test+special+exam/block-v1:test+special+exam+type@sequential+block@abc123",
+      "in_timed_exam": true,
+      "software_download_url": "",
+      "taking_as_proctored": false,
+      "time_remaining_seconds": 1799.9,
+      "total_time": "30 minutes",
+    },
+    "allowProctoringOptOut": false,
+    "apiErrorMsg": "",
+    "exam": Object {},
+    "examAccessToken": Object {
+      "exam_access_token": "",
+      "exam_access_token_expiration": "",
+    },
+    "isLoading": false,
+    "proctoringSettings": Object {
+      "contact_us": "",
+      "exam_proctoring_backend": Object {
+        "download_url": "",
+        "instructions": Array [],
+        "name": "",
+        "rules": Object {},
+      },
+      "integration_specific_email": "",
+      "learner_notification_from_email": "",
+      "link_urls": null,
+      "platform_name": "",
+      "provider_name": "",
+      "provider_tech_support_email": "",
+      "provider_tech_support_phone": "",
+    },
+    "timeIsOver": false,
+  },
+}
+`;
+
 exports[`Data layer integration tests Test getProctoringSettings Should fail to fetch if error occurs 1`] = `
 Object {
   "exam_proctoring_backend": Object {
@@ -295,7 +344,27 @@ Object {
 }
 `;
 
-exports[`Data layer integration tests Test pollAttempt Should poll exam attempt, and update attempt and exam 1`] = `
+exports[`Data layer integration tests Test pollAttempt Should poll and update active attempt 1`] = `
+Object {
+  "accessibility_time_string": "you have 29 minutes remaining",
+  "attempt_code": "",
+  "attempt_id": 1,
+  "attempt_status": "started",
+  "course_id": "course-v1:test+special+exam",
+  "desktop_application_js_url": "",
+  "exam_display_name": "timed",
+  "exam_started_poll_url": "/api/edx_proctoring/v1/proctored_exam/attempt/1",
+  "exam_type": "a timed exam",
+  "exam_url_path": "http://localhost:2000/course/course-v1:test+special+exam/block-v1:test+special+exam+type@sequential+block@abc123",
+  "in_timed_exam": true,
+  "software_download_url": "",
+  "taking_as_proctored": false,
+  "time_remaining_seconds": 1739.9,
+  "total_time": "30 minutes",
+}
+`;
+
+exports[`Data layer integration tests Test pollAttempt with edx-proctoring as a backend (no EXAMS_BASE_URL) Should poll and update active attempt 1`] = `
 Object {
   "attempt_code": "",
   "attempt_id": 1,
@@ -314,7 +383,7 @@ Object {
 }
 `;
 
-exports[`Data layer integration tests Test pollAttempt Should poll exam attempt, and update attempt and exam 2`] = `
+exports[`Data layer integration tests Test pollAttempt with edx-proctoring as a backend (no EXAMS_BASE_URL) Should poll and update active attempt 2`] = `
 Object {
   "attempt_code": "",
   "attempt_id": 1,
@@ -333,12 +402,84 @@ Object {
 }
 `;
 
-exports[`Data layer integration tests Test resetExam Should reset exam, and update attempt and exam 1`] = `
+exports[`Data layer integration tests Test resetExam Should reset exam attempt 1`] = `
 Object {
   "examState": Object {
     "activeAttempt": null,
     "allowProctoringOptOut": false,
-    "apiErrorMsg": "Request failed with status code 404",
+    "apiErrorMsg": "",
+    "exam": Object {
+      "attempt": Object {
+        "accessibility_time_string": "you have 30 minutes remaining",
+        "attempt_code": "",
+        "attempt_id": 2,
+        "attempt_status": "created",
+        "course_id": "course-v1:test+special+exam",
+        "desktop_application_js_url": "",
+        "exam_display_name": "timed",
+        "exam_started_poll_url": "/api/edx_proctoring/v1/proctored_exam/attempt/1",
+        "exam_type": "a timed exam",
+        "exam_url_path": "http://localhost:2000/course/course-v1:test+special+exam/block-v1:test+special+exam+type@sequential+block@abc123",
+        "in_timed_exam": true,
+        "software_download_url": "",
+        "taking_as_proctored": false,
+        "time_remaining_seconds": 1799.9,
+        "total_time": "30 minutes",
+      },
+      "backend": "test",
+      "content_id": "block-v1:test+special+exam+type@sequential+block@abc123",
+      "course_id": "course-v1:test+special+exam",
+      "due_date": null,
+      "exam_name": "prock exam",
+      "external_id": null,
+      "hide_after_due": false,
+      "id": 1,
+      "is_active": true,
+      "is_practice_exam": false,
+      "is_proctored": false,
+      "prerequisite_status": Object {
+        "are_prerequisites_satisifed": true,
+        "declined_prerequisites": Array [],
+        "failed_prerequisites": Array [],
+        "pending_prerequisites": Array [],
+        "satisfied_prerequisites": Array [],
+      },
+      "time_limit_mins": 30,
+      "total_time": "30 minutes",
+      "type": "timed",
+    },
+    "examAccessToken": Object {
+      "exam_access_token": "",
+      "exam_access_token_expiration": "",
+    },
+    "isLoading": false,
+    "proctoringSettings": Object {
+      "contact_us": "",
+      "exam_proctoring_backend": Object {
+        "download_url": "",
+        "instructions": Array [],
+        "name": "",
+        "rules": Object {},
+      },
+      "integration_specific_email": "",
+      "learner_notification_from_email": "",
+      "link_urls": null,
+      "platform_name": "",
+      "provider_name": "",
+      "provider_tech_support_email": "",
+      "provider_tech_support_phone": "",
+    },
+    "timeIsOver": false,
+  },
+}
+`;
+
+exports[`Data layer integration tests Test resetExam with edx-proctoring as backend (no EXAMS_BASE_URL) Should reset exam attempt 1`] = `
+Object {
+  "examState": Object {
+    "activeAttempt": null,
+    "allowProctoringOptOut": false,
+    "apiErrorMsg": "",
     "exam": Object {
       "attempt": Object {
         "attempt_code": "",
@@ -420,8 +561,48 @@ Object {
 }
 `;
 
+exports[`Data layer integration tests Test startProctoredExam with edx-proctoring as a backend (no EXAMS_BASE_URL) Should start exam, and update attempt and exam 1`] = `
+Object {
+  "accessibility_time_string": "you have 30 minutes remaining",
+  "attempt_code": "",
+  "attempt_id": 1,
+  "attempt_status": "started",
+  "course_id": "course-v1:test+special+exam",
+  "desktop_application_js_url": "",
+  "exam_display_name": "timed",
+  "exam_started_poll_url": "/api/edx_proctoring/v1/proctored_exam/attempt/1",
+  "exam_type": "a timed exam",
+  "exam_url_path": "http://localhost:2000/course/course-v1:test+special+exam/block-v1:test+special+exam+type@sequential+block@abc123",
+  "in_timed_exam": true,
+  "software_download_url": "",
+  "taking_as_proctored": false,
+  "time_remaining_seconds": 1799.9,
+  "total_time": "30 minutes",
+}
+`;
+
 exports[`Data layer integration tests Test startTimedExam Should start exam, and update attempt and exam 1`] = `
 Object {
+  "attempt_code": "",
+  "attempt_id": 1,
+  "attempt_status": "started",
+  "course_id": "course-v1:test+special+exam",
+  "desktop_application_js_url": "",
+  "exam_display_name": "timed",
+  "exam_started_poll_url": "/api/edx_proctoring/v1/proctored_exam/attempt/1",
+  "exam_type": "a timed exam",
+  "exam_url_path": "http://localhost:2000/course/course-v1:test+special+exam/block-v1:test+special+exam+type@sequential+block@abc123",
+  "in_timed_exam": true,
+  "software_download_url": "",
+  "taking_as_proctored": false,
+  "time_remaining_seconds": 1799.9,
+  "total_time": "30 minutes",
+}
+`;
+
+exports[`Data layer integration tests Test startTimedExam with edx-proctoring as a backend (no EXAMS_BASE_URL) Should start exam, and update attempt and exam 1`] = `
+Object {
+  "accessibility_time_string": "you have 30 minutes remaining",
   "attempt_code": "",
   "attempt_id": 1,
   "attempt_status": "started",

--- a/src/data/api.js
+++ b/src/data/api.js
@@ -70,9 +70,9 @@ export async function pollExamAttempt(url) {
   return data;
 }
 
-export async function createExamAttempt(examId, startClock = true, attemptProctored = false) {
+export async function createExamAttempt(examId, legacyAttempt, startClock = true, attemptProctored = false) {
   let urlString;
-  if (!getConfig().EXAMS_BASE_URL) {
+  if (!getConfig().EXAMS_BASE_URL || legacyAttempt) {
     urlString = `${getConfig().LMS_BASE_URL}${BASE_API_URL}`;
   } else {
     urlString = `${getConfig().EXAMS_BASE_URL}/api/v1/exams/attempt`;
@@ -87,9 +87,9 @@ export async function createExamAttempt(examId, startClock = true, attemptProcto
   return data;
 }
 
-export async function updateAttemptStatus(attemptId, action, detail = null) {
+export async function updateAttemptStatus(attemptId, action, legacyAttempt, detail = null) {
   let urlString;
-  if (!getConfig().EXAMS_BASE_URL) {
+  if (!getConfig().EXAMS_BASE_URL || legacyAttempt) {
     urlString = `${getConfig().LMS_BASE_URL}${BASE_API_URL}/${attemptId}`;
   } else {
     urlString = `${getConfig().EXAMS_BASE_URL}/api/v1/exams/attempt/${attemptId}`;
@@ -103,32 +103,32 @@ export async function updateAttemptStatus(attemptId, action, detail = null) {
   return data;
 }
 
-export async function stopAttempt(attemptId) {
-  return updateAttemptStatus(attemptId, ExamAction.STOP);
+export async function stopAttempt(attemptId, legacyAttempt = false) {
+  return updateAttemptStatus(attemptId, ExamAction.STOP, legacyAttempt);
 }
 
-export async function continueAttempt(attemptId) {
-  return updateAttemptStatus(attemptId, ExamAction.START);
+export async function continueAttempt(attemptId, legacyAttempt = false) {
+  return updateAttemptStatus(attemptId, ExamAction.START, legacyAttempt);
 }
 
-export async function submitAttempt(attemptId) {
-  return updateAttemptStatus(attemptId, ExamAction.SUBMIT);
+export async function submitAttempt(attemptId, legacyAttempt = false) {
+  return updateAttemptStatus(attemptId, ExamAction.SUBMIT, legacyAttempt);
 }
 
-export async function resetAttempt(attemptId) {
-  return updateAttemptStatus(attemptId, ExamAction.RESET);
+export async function resetAttempt(attemptId, legacyAttempt = false) {
+  return updateAttemptStatus(attemptId, ExamAction.RESET, legacyAttempt);
 }
 
-export async function endExamWithFailure(attemptId, error) {
-  return updateAttemptStatus(attemptId, ExamAction.ERROR, error);
+export async function endExamWithFailure(attemptId, error, legacyAttempt = false) {
+  return updateAttemptStatus(attemptId, ExamAction.ERROR, legacyAttempt, error);
 }
 
-export async function softwareDownloadAttempt(attemptId) {
-  return updateAttemptStatus(attemptId, ExamAction.CLICK_DOWNLOAD_SOFTWARE);
+export async function softwareDownloadAttempt(attemptId, legacyAttempt = false) {
+  return updateAttemptStatus(attemptId, ExamAction.CLICK_DOWNLOAD_SOFTWARE, legacyAttempt);
 }
 
-export async function declineAttempt(attemptId) {
-  return updateAttemptStatus(attemptId, ExamAction.DECLINE);
+export async function declineAttempt(attemptId, legacyAttempt = false) {
+  return updateAttemptStatus(attemptId, ExamAction.DECLINE, legacyAttempt);
 }
 
 export async function fetchExamReviewPolicy(examId) {

--- a/src/data/redux.test.jsx
+++ b/src/data/redux.test.jsx
@@ -4,12 +4,11 @@ import MockAdapter from 'axios-mock-adapter';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig, mergeConfig } from '@edx/frontend-platform';
 
-import { isExam, fetchExamAccess, getExamAccess } from '../api';
 import * as thunks from './thunks';
 
 import executeThunk from '../utils';
 
-import { initializeTestStore, initializeMockApp } from '../setupTest';
+import { initializeTestStore, initializeMockApp, initializeTestConfig } from '../setupTest';
 import { ExamStatus } from '../constants';
 
 const BASE_API_URL = '/api/edx_proctoring/v1/proctored_exam/attempt';
@@ -35,12 +34,23 @@ jest.mock('./messages/handlers', () => ({
 describe('Data layer integration tests', () => {
   const exam = Factory.build('exam', { attempt: Factory.build('attempt') });
   const { course_id: courseId, content_id: contentId, attempt } = exam;
-  const fetchExamAttemptsDataUrl = `${getConfig().LMS_BASE_URL}${BASE_API_URL}/course_id/${courseId}`
+  const fetchExamAttemptsDataLegacyUrl = `${getConfig().LMS_BASE_URL}${BASE_API_URL}/course_id/${courseId}`
     + `?content_id=${encodeURIComponent(contentId)}&is_learning_mfe=true`;
-  const updateAttemptStatusUrl = `${getConfig().LMS_BASE_URL}${BASE_API_URL}/${attempt.attempt_id}`;
+  const updateAttemptStatusLegacyUrl = `${getConfig().LMS_BASE_URL}${BASE_API_URL}/${attempt.attempt_id}`;
+
+  const createUpdateAttemptURL = `${getConfig().EXAMS_BASE_URL}/api/v1/exams/attempt`;
+  const fetchExamAttemptsDataUrl = `${getConfig().EXAMS_BASE_URL}/api/v1/student/exam/attempt/course_id/${courseId}/content_id/${contentId}`;
+  const latestAttemptURL = `${getConfig().EXAMS_BASE_URL}/api/v1/exams/attempt/latest`;
   let store;
 
+  const initWithExamAttempt = async (testExam = exam, testAttempt = attempt) => {
+    axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: testExam });
+    axiosMock.onGet(latestAttemptURL).reply(200, testAttempt);
+    await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+  };
+
   beforeEach(async () => {
+    initializeTestConfig();
     windowSpy = jest.spyOn(window, 'window', 'get');
     axiosMock.reset();
     loggingService.logError.mockReset();
@@ -61,7 +71,8 @@ describe('Data layer integration tests', () => {
 
   describe('Test getExamAttemptsData', () => {
     it('Should get, and save exam and attempt', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam, active_attempt: attempt });
+      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam });
+      axiosMock.onGet(latestAttemptURL).replyOnce(200, attempt);
 
       await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
 
@@ -83,8 +94,12 @@ describe('Data layer integration tests', () => {
     const fetchProctoringSettingsUrl = `${getConfig().LMS_BASE_URL}/api/edx_proctoring/v1/proctored_exam/settings/exam_id/${exam.id}/`;
     const proctoringSettings = Factory.build('proctoringSettings');
 
+    beforeEach(async () => {
+      mergeConfig({ EXAMS_BASE_URL: null });
+    });
+
     it('Should get, and save proctoringSettings', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam, active_attempt: attempt });
+      axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).reply(200, { exam, active_attempt: attempt });
       axiosMock.onGet(fetchProctoringSettingsUrl).reply(200, proctoringSettings);
 
       await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
@@ -105,7 +120,7 @@ describe('Data layer integration tests', () => {
     });
 
     it('Should fail to fetch if error occurs', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam, active_attempt: attempt });
+      axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).reply(200, { exam, active_attempt: attempt });
       axiosMock.onGet(fetchProctoringSettingsUrl).networkError();
 
       await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
@@ -120,8 +135,12 @@ describe('Data layer integration tests', () => {
     const getExamReviewPolicyUrl = `${getConfig().LMS_BASE_URL}/api/edx_proctoring/v1/proctored_exam/review_policy/exam_id/${exam.id}/`;
     const reviewPolicy = 'Example review policy.';
 
+    beforeEach(async () => {
+      mergeConfig({ EXAMS_BASE_URL: null });
+    });
+
     it('Should get, and save getExamReviewPolicy', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam, active_attempt: attempt });
+      axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).reply(200, { exam, active_attempt: attempt });
       axiosMock.onGet(getExamReviewPolicyUrl).reply(200, { review_policy: reviewPolicy });
 
       await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
@@ -132,7 +151,7 @@ describe('Data layer integration tests', () => {
     });
 
     it('Should fail to fetch if error occurs', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam, active_attempt: attempt });
+      axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).reply(200, { exam, active_attempt: attempt });
       axiosMock.onGet(getExamReviewPolicyUrl).networkError();
 
       await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
@@ -154,24 +173,45 @@ describe('Data layer integration tests', () => {
   });
 
   describe('Test startTimedExam', () => {
-    const createExamAttemptUrl = `${getConfig().LMS_BASE_URL}${BASE_API_URL}`;
+    describe('with edx-proctoring as a backend (no EXAMS_BASE_URL)', () => {
+      beforeEach(() => {
+        mergeConfig({ EXAMS_BASE_URL: null });
+      });
+
+      it('Should start exam, and update attempt and exam', async () => {
+        const createExamAttemptUrl = `${getConfig().LMS_BASE_URL}${BASE_API_URL}`;
+        axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).replyOnce(200, { exam, active_attempt: {} });
+        axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).reply(200, { exam, active_attempt: attempt });
+        axiosMock.onPost(createExamAttemptUrl).reply(200, { exam_attempt_id: attempt.attempt_id });
+
+        await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+        let state = store.getState();
+        expect(state.examState.activeAttempt).toBeNull();
+
+        await executeThunk(thunks.startTimedExam(), store.dispatch, store.getState);
+        state = store.getState();
+        expect(state.examState.activeAttempt).toMatchSnapshot();
+      });
+    });
 
     it('Should start exam, and update attempt and exam', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam, active_attempt: {} });
-      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam, active_attempt: attempt });
-      axiosMock.onPost(createExamAttemptUrl).reply(200, { exam_attempt_id: attempt.attempt_id });
+      await initWithExamAttempt(exam, {});
 
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
-      let state = store.getState();
-      expect(state.examState.activeAttempt).toBeNull();
+      axiosMock.onGet(latestAttemptURL).reply(200, attempt);
+      axiosMock.onPost(createUpdateAttemptURL).reply(200, { exam_attempt_id: attempt.attempt_id });
 
       await executeThunk(thunks.startTimedExam(), store.dispatch, store.getState);
-      state = store.getState();
+      const state = store.getState();
       expect(state.examState.activeAttempt).toMatchSnapshot();
+      expect(axiosMock.history.post[0].data).toEqual(JSON.stringify({
+        exam_id: exam.id,
+        start_clock: 'true',
+        attempt_proctored: 'false',
+      }));
     });
 
     it('Should fail to fetch if no exam id', async () => {
-      axiosMock.onPost(createExamAttemptUrl).reply(200, { exam_attempt_id: attempt.attempt_id });
+      axiosMock.onPost(createUpdateAttemptURL).reply(200, { exam_attempt_id: attempt.attempt_id });
 
       await executeThunk(thunks.startTimedExam(), store.dispatch, store.getState);
 
@@ -185,48 +225,91 @@ describe('Data layer integration tests', () => {
     const readyToSubmitAttempt = Factory.build('attempt', { attempt_status: ExamStatus.READY_TO_SUBMIT });
     const readyToSubmitExam = Factory.build('exam', { attempt: readyToSubmitAttempt });
 
-    it('Should stop exam, and update attempt and exam', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam, active_attempt: attempt });
-      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: readyToSubmitExam, active_attempt: {} });
-      axiosMock.onPut(updateAttemptStatusUrl).reply(200, { exam_attempt_id: readyToSubmitAttempt.attempt_id });
+    describe('with edx-proctoring as a backend (no EXAMS_BASE_URL)', () => {
+      beforeEach(() => {
+        mergeConfig({ EXAMS_BASE_URL: null });
+      });
 
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      it('Should stop exam, and update attempt', async () => {
+        axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).replyOnce(200, { exam, active_attempt: attempt });
+        axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).reply(200, { exam: readyToSubmitExam, active_attempt: {} });
+        axiosMock.onPut(updateAttemptStatusLegacyUrl).reply(200, { exam_attempt_id: readyToSubmitAttempt.attempt_id });
+
+        await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+        let state = store.getState();
+        expect(state.examState.activeAttempt.attempt_status).toBe(ExamStatus.STARTED);
+
+        await executeThunk(thunks.stopExam(), store.dispatch, store.getState);
+        state = store.getState();
+        expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.READY_TO_SUBMIT);
+        expect(axiosMock.history.put[0].url).toEqual(updateAttemptStatusLegacyUrl);
+        expect(axiosMock.history.put[0].data).toEqual(JSON.stringify({ action: 'stop' }));
+      });
+
+      it('Should stop exam, and redirect to sequence if not in exam section', async () => {
+        const { location } = window;
+        delete window.location;
+        window.location = {
+          href: '',
+        };
+
+        axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).replyOnce(200, { exam: {}, active_attempt: attempt });
+        axiosMock.onPut(updateAttemptStatusLegacyUrl).reply(200, { exam_attempt_id: readyToSubmitAttempt.attempt_id });
+
+        await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+        const state = store.getState();
+        expect(state.examState.activeAttempt.attempt_status).toBe(ExamStatus.STARTED);
+
+        await executeThunk(thunks.stopExam(), store.dispatch, store.getState);
+        expect(axiosMock.history.put[0].url).toEqual(updateAttemptStatusLegacyUrl);
+        expect(window.location.href).toEqual(attempt.exam_url_path);
+
+        window.location = location;
+      });
+    });
+
+    it('Should stop exam, and update attempt', async () => {
+      await initWithExamAttempt();
       let state = store.getState();
       expect(state.examState.activeAttempt.attempt_status).toBe(ExamStatus.STARTED);
+
+      axiosMock.onPut(`${createUpdateAttemptURL}/${readyToSubmitAttempt.attempt_id}`).reply(200, { exam_attempt_id: readyToSubmitAttempt.attempt_id });
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: readyToSubmitExam });
+      axiosMock.onGet(latestAttemptURL).reply(200, readyToSubmitAttempt);
 
       await executeThunk(thunks.stopExam(), store.dispatch, store.getState);
       state = store.getState();
       expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.READY_TO_SUBMIT);
+      expect(axiosMock.history.put[0].url).toEqual(`${createUpdateAttemptURL}/${readyToSubmitAttempt.attempt_id}`);
+      expect(axiosMock.history.put[0].data).toEqual(JSON.stringify({ action: 'stop' }));
     });
 
-    it('Should stop exam, and redirect to sequence if no exam attempt', async () => {
+    it('Should stop exam, and redirect to sequence if not in exam section', async () => {
       const { location } = window;
       delete window.location;
       window.location = {
         href: '',
       };
 
-      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam: {}, active_attempt: attempt });
-      axiosMock.onPut(updateAttemptStatusUrl).reply(200, { exam_attempt_id: readyToSubmitAttempt.attempt_id });
-
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      await initWithExamAttempt({}, attempt);
       const state = store.getState();
       expect(state.examState.activeAttempt.attempt_status).toBe(ExamStatus.STARTED);
 
+      axiosMock.onPut(`${createUpdateAttemptURL}/${readyToSubmitAttempt.attempt_id}`).reply(200, { exam_attempt_id: readyToSubmitAttempt.attempt_id });
+
       await executeThunk(thunks.stopExam(), store.dispatch, store.getState);
-      expect(axiosMock.history.put[0].url).toEqual(updateAttemptStatusUrl);
+      expect(axiosMock.history.put[0].url).toEqual(`${createUpdateAttemptURL}/${readyToSubmitAttempt.attempt_id}`);
       expect(window.location.href).toEqual(attempt.exam_url_path);
 
       window.location = location;
     });
 
     it('Should fail to fetch if error occurs', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam: {}, active_attempt: attempt });
-      axiosMock.onPut(updateAttemptStatusUrl).networkError();
-
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      await initWithExamAttempt();
       let state = store.getState();
       expect(state.examState.activeAttempt.attempt_status).toBe(ExamStatus.STARTED);
+
+      axiosMock.onPut(`${createUpdateAttemptURL}/${attempt.attempt_id}`).networkError();
 
       await executeThunk(thunks.stopExam(), store.dispatch, store.getState);
       state = store.getState();
@@ -234,10 +317,8 @@ describe('Data layer integration tests', () => {
     });
 
     it('Should fail to fetch if no active attempt', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: Factory.build('exam'), active_attempt: {} });
-      axiosMock.onGet(updateAttemptStatusUrl).reply(200, { exam_attempt_id: readyToSubmitAttempt.attempt_id });
+      await initWithExamAttempt(exam, {});
 
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
       await executeThunk(thunks.stopExam(), store.dispatch, store.getState);
 
       const state = store.getState();
@@ -250,25 +331,48 @@ describe('Data layer integration tests', () => {
     const readyToSubmitAttempt = Factory.build('attempt', { attempt_status: ExamStatus.READY_TO_SUBMIT });
     const readyToSubmitExam = Factory.build('exam', { attempt: readyToSubmitAttempt });
 
-    it('Should stop exam, and update attempt and exam', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam: readyToSubmitExam, active_attempt: {} });
-      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam, active_attempt: attempt });
-      axiosMock.onPost(updateAttemptStatusUrl).reply(200, { exam_attempt_id: attempt.attempt_id });
+    describe('with edx-proctoring as backend (no EXAMS_BASE_URL)', () => {
+      beforeEach(() => {
+        mergeConfig({ EXAMS_BASE_URL: null });
+      });
 
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      it('Should return to exam, and update attempt', async () => {
+        axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).replyOnce(200, { exam: readyToSubmitExam, active_attempt: {} });
+        axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).reply(200, { exam, active_attempt: attempt });
+        axiosMock.onPut(updateAttemptStatusLegacyUrl).reply(200, { exam_attempt_id: attempt.attempt_id });
+
+        await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+        let state = store.getState();
+        expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.READY_TO_SUBMIT);
+
+        await executeThunk(thunks.continueExam(), store.dispatch, store.getState);
+        state = store.getState();
+        expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.STARTED);
+        expect(axiosMock.history.put[0].url).toEqual(updateAttemptStatusLegacyUrl);
+        expect(axiosMock.history.put[0].data).toEqual(JSON.stringify({ action: 'start' }));
+      });
+    });
+
+    it('Should return to exam, and update attempt', async () => {
+      await initWithExamAttempt(readyToSubmitExam, {});
       let state = store.getState();
       expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.READY_TO_SUBMIT);
+
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam });
+      axiosMock.onGet(latestAttemptURL).reply(200, { attempt });
+      axiosMock.onPut(`${createUpdateAttemptURL}/${attempt.attempt_id}`).reply(200, { exam_attempt_id: attempt.attempt_id });
 
       await executeThunk(thunks.continueExam(), store.dispatch, store.getState);
       state = store.getState();
       expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.STARTED);
+      expect(axiosMock.history.put[0].url).toEqual(`${createUpdateAttemptURL}/${attempt.attempt_id}`);
+      expect(axiosMock.history.put[0].data).toEqual(JSON.stringify({ action: 'start' }));
     });
 
     it('Should fail to fetch if no attempt id', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: Factory.build('exam'), active_attempt: {} });
-      axiosMock.onGet(updateAttemptStatusUrl).reply(200, { exam_attempt_id: attempt.attempt_id });
+      await initWithExamAttempt(Factory.build('exam'), {});
 
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      axiosMock.onGet(`${createUpdateAttemptURL}/${attempt.attempt_id}`).reply(200, { exam_attempt_id: attempt.attempt_id });
       await executeThunk(thunks.continueExam(), store.dispatch, store.getState);
 
       const state = store.getState();
@@ -285,27 +389,54 @@ describe('Data layer integration tests', () => {
       });
     const examWithCreatedAttempt = Factory.build('exam', { attempt: createdAttempt });
 
-    it('Should reset exam, and update attempt and exam', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam, active_attempt: attempt });
-      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: examWithCreatedAttempt, active_attempt: {} });
-      axiosMock.onPost(updateAttemptStatusUrl).reply(200, { exam_attempt_id: createdAttempt.attempt_id });
+    describe('with edx-proctoring as backend (no EXAMS_BASE_URL)', () => {
+      beforeEach(() => {
+        mergeConfig({ EXAMS_BASE_URL: null });
+      });
 
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      it('Should reset exam attempt', async () => {
+        axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).replyOnce(200, { exam, active_attempt: attempt });
+        axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).reply(200, {
+          exam: examWithCreatedAttempt, active_attempt: {},
+        });
+        axiosMock.onPut(updateAttemptStatusLegacyUrl).reply(200, { exam_attempt_id: createdAttempt.attempt_id });
+
+        await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+        let state = store.getState();
+        expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.STARTED);
+
+        await executeThunk(thunks.resetExam(), store.dispatch, store.getState);
+
+        state = store.getState();
+        expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.CREATED);
+        expect(state).toMatchSnapshot();
+        expect(axiosMock.history.put[0].url).toEqual(updateAttemptStatusLegacyUrl);
+        expect(axiosMock.history.put[0].data).toEqual(JSON.stringify({ action: 'reset_attempt' }));
+      });
+    });
+
+    it('Should reset exam attempt', async () => {
+      await initWithExamAttempt();
       let state = store.getState();
       expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.STARTED);
 
-      await executeThunk(thunks.continueExam(), store.dispatch, store.getState);
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: examWithCreatedAttempt });
+      axiosMock.onGet(latestAttemptURL).reply(200, {});
+      axiosMock.onPut(`${createUpdateAttemptURL}/${attempt.attempt_id}`).reply(200, { exam_attempt_id: createdAttempt.attempt_id });
+
+      await executeThunk(thunks.resetExam(), store.dispatch, store.getState);
 
       state = store.getState();
       expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.CREATED);
       expect(state).toMatchSnapshot();
+      expect(axiosMock.history.put[0].url).toEqual(`${createUpdateAttemptURL}/${attempt.attempt_id}`);
+      expect(axiosMock.history.put[0].data).toEqual(JSON.stringify({ action: 'reset_attempt' }));
     });
 
     it('Should fail to fetch if no attempt id', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: Factory.build('exam'), active_attempt: {} });
-      axiosMock.onGet(updateAttemptStatusUrl).reply(200, { exam_attempt_id: createdAttempt.attempt_id });
+      await initWithExamAttempt(Factory.build('exam'), {});
+      axiosMock.onPut(`${createUpdateAttemptURL}/${createdAttempt.attempt_id}`).reply(200, { exam_attempt_id: createdAttempt.attempt_id });
 
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
       await executeThunk(thunks.resetExam(), store.dispatch, store.getState);
 
       const state = store.getState();
@@ -318,25 +449,44 @@ describe('Data layer integration tests', () => {
     const submittedAttempt = Factory.build('attempt', { attempt_status: ExamStatus.SUBMITTED });
     const submittedExam = Factory.build('exam', { attempt: submittedAttempt });
 
-    it('Should submit exam, and update attempt and exam', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam, active_attempt: attempt });
-      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: submittedExam, active_attempt: {} });
-      axiosMock.onPost(updateAttemptStatusUrl).reply(200, { exam_attempt_id: submittedAttempt.attempt_id });
+    describe('with edx-proctoring as backend (no EXAMS_BASE_URL)', () => {
+      beforeEach(() => {
+        mergeConfig({ EXAMS_BASE_URL: null });
+      });
 
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      it('Should submit exam, and update attempt and exam', async () => {
+        axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).replyOnce(200, { exam, active_attempt: attempt });
+        axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).reply(200, { exam: submittedExam, active_attempt: {} });
+        axiosMock.onPost(updateAttemptStatusLegacyUrl).reply(200, { exam_attempt_id: submittedAttempt.attempt_id });
+
+        await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+        let state = store.getState();
+        expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.STARTED);
+
+        await executeThunk(thunks.submitExam(), store.dispatch, store.getState);
+        state = store.getState();
+        expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.SUBMITTED);
+      });
+    });
+
+    it('Should submit exam, and update attempt and exam', async () => {
+      await initWithExamAttempt();
       let state = store.getState();
       expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.STARTED);
+
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: submittedExam });
+      axiosMock.onPut(`${createUpdateAttemptURL}/${attempt.attempt_id}`).reply(200, { exam_attempt_id: submittedAttempt.attempt_id });
 
       await executeThunk(thunks.submitExam(), store.dispatch, store.getState);
       state = store.getState();
       expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.SUBMITTED);
+      expect(axiosMock.history.put[0].url).toEqual(`${createUpdateAttemptURL}/${attempt.attempt_id}`);
+      expect(axiosMock.history.put[0].data).toEqual(JSON.stringify({ action: 'submit' }));
     });
 
     it('Should fail to fetch if no attempt id', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: Factory.build('exam'), active_attempt: {} });
-      axiosMock.onGet(updateAttemptStatusUrl).reply(200, { exam_attempt_id: submittedAttempt.attempt_id });
+      await initWithExamAttempt(Factory.build('exam'), {});
 
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
       await executeThunk(thunks.submitExam(), store.dispatch, store.getState);
 
       const state = store.getState();
@@ -354,32 +504,17 @@ describe('Data layer integration tests', () => {
         href: '',
       };
 
-      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam: {}, active_attempt: attempt });
-      axiosMock.onPut(updateAttemptStatusUrl).reply(200, { exam_attempt_id: submittedAttempt.attempt_id });
-
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      await initWithExamAttempt({}, attempt);
       const state = store.getState();
       expect(state.examState.activeAttempt.attempt_status).toBe(ExamStatus.STARTED);
 
+      axiosMock.onPut(`${createUpdateAttemptURL}/${attempt.attempt_id}`).reply(200, { exam_attempt_id: submittedAttempt.attempt_id });
+
       await executeThunk(thunks.submitExam(), store.dispatch, store.getState);
-      expect(axiosMock.history.put[0].url).toEqual(updateAttemptStatusUrl);
+      expect(axiosMock.history.put[0].url).toEqual(`${createUpdateAttemptURL}/${attempt.attempt_id}`);
       expect(window.location.href).toEqual(attempt.exam_url_path);
 
       window.location = location;
-    });
-
-    it('Should fail to fetch if error occurs', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam: {}, active_attempt: attempt });
-      axiosMock.onPut(updateAttemptStatusUrl).networkError();
-
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
-      let state = store.getState();
-      expect(state.examState.activeAttempt.attempt_status).toBe(ExamStatus.STARTED);
-
-      await executeThunk(thunks.submitExam(), store.dispatch, store.getState);
-      state = store.getState();
-      expect(state.examState.apiErrorMsg).toBe('Network Error');
-      expect(state.examState.activeAttempt.attempt_status).toBe(ExamStatus.STARTED);
     });
   });
 
@@ -387,26 +522,46 @@ describe('Data layer integration tests', () => {
     const submittedAttempt = Factory.build('attempt', { attempt_status: ExamStatus.SUBMITTED });
     const submittedExam = Factory.build('exam', { attempt: submittedAttempt });
 
-    it('Should expire exam, and update attempt and exam', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam, active_attempt: attempt });
-      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: submittedExam, active_attempt: {} });
-      axiosMock.onPost(updateAttemptStatusUrl).reply(200, { exam_attempt_id: submittedAttempt.attempt_id });
+    describe('with edx-proctoring as backend (no EXAMS_BASE_URL)', () => {
+      beforeEach(() => {
+        mergeConfig({ EXAMS_BASE_URL: null });
+      });
 
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      it('Should expire exam, and update attempt', async () => {
+        axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).replyOnce(200, { exam, active_attempt: attempt });
+        axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).reply(200, { exam: submittedExam, active_attempt: {} });
+        axiosMock.onPut(updateAttemptStatusLegacyUrl).reply(200, { exam_attempt_id: submittedAttempt.attempt_id });
+
+        await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+        let state = store.getState();
+        expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.STARTED);
+
+        await executeThunk(thunks.expireExam(), store.dispatch, store.getState);
+        state = store.getState();
+        expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.SUBMITTED);
+        expect(state.examState.timeIsOver).toBe(true);
+      });
+    });
+
+    it('Should submit expired exam, and update attempt', async () => {
+      await initWithExamAttempt();
       let state = store.getState();
       expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.STARTED);
+
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: submittedExam });
+      axiosMock.onGet(latestAttemptURL).reply(200, submittedAttempt);
+      axiosMock.onPut(`${createUpdateAttemptURL}/${attempt.attempt_id}`).reply(200, { exam_attempt_id: submittedAttempt.attempt_id });
 
       await executeThunk(thunks.expireExam(), store.dispatch, store.getState);
       state = store.getState();
       expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.SUBMITTED);
       expect(state.examState.timeIsOver).toBe(true);
+      expect(axiosMock.history.put[0].url).toEqual(`${createUpdateAttemptURL}/${attempt.attempt_id}`);
+      expect(axiosMock.history.put[0].data).toEqual(JSON.stringify({ action: 'submit' }));
     });
 
     it('Should fail to fetch if no attempt id', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: Factory.build('exam'), active_attempt: {} });
-      axiosMock.onGet(updateAttemptStatusUrl).reply(200, { exam_attempt_id: submittedAttempt.attempt_id });
-
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      await initWithExamAttempt(Factory.build('exam'), {});
       await executeThunk(thunks.expireExam(), store.dispatch, store.getState);
 
       const state = store.getState();
@@ -419,28 +574,41 @@ describe('Data layer integration tests', () => {
     const softwareDownloadedAttempt = Factory.build('attempt', { attempt_status: ExamStatus.DOWNLOAD_SOFTWARE_CLICKED });
     const softwareDownloadedExam = Factory.build('exam', { attempt: softwareDownloadedAttempt });
 
-    it('Should start downloading proctoring software, and update attempt and exam', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam, active_attempt: attempt });
-      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: softwareDownloadedExam, active_attempt: {} });
-      axiosMock.onPost(updateAttemptStatusUrl).reply(200, { exam_attempt_id: softwareDownloadedAttempt.attempt_id });
+    describe('with edx-proctoring as backend (no EXAMS_BASE_URL)', () => {
+      beforeEach(() => {
+        mergeConfig({ EXAMS_BASE_URL: null });
+      });
 
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
-      let state = store.getState();
-      expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.STARTED);
+      it('Should start downloading proctoring software, and update attempt and exam', async () => {
+        axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).replyOnce(200, { exam, active_attempt: attempt });
+        axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).reply(200, {
+          exam: softwareDownloadedExam, active_attempt: {},
+        });
+        axiosMock.onPut(updateAttemptStatusLegacyUrl).reply(200, {
+          exam_attempt_id: softwareDownloadedAttempt.attempt_id,
+        });
 
-      await executeThunk(thunks.startProctoringSoftwareDownload(), store.dispatch, store.getState);
-      state = store.getState();
-      expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.DOWNLOAD_SOFTWARE_CLICKED);
+        await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+        let state = store.getState();
+        expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.STARTED);
+
+        await executeThunk(thunks.startProctoringSoftwareDownload(), store.dispatch, store.getState);
+        state = store.getState();
+        expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.DOWNLOAD_SOFTWARE_CLICKED);
+      });
     });
 
-    it('Should fail to start if no attempt id', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: Factory.build('exam'), active_attempt: {} });
-      axiosMock.onGet(updateAttemptStatusUrl).reply(200, { exam_attempt_id: softwareDownloadedAttempt.attempt_id });
+    it('Should start downloading proctoring software, and update attempt and exam', async () => {
+      await initWithExamAttempt();
 
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: softwareDownloadedExam, active_attempt: {} });
+      axiosMock.onPut(`${createUpdateAttemptURL}/${softwareDownloadedAttempt.attempt_id}`).reply(200, { exam_attempt_id: softwareDownloadedAttempt.attempt_id });
+
       await executeThunk(thunks.startProctoringSoftwareDownload(), store.dispatch, store.getState);
-
-      expect(loggingService.logError).toHaveBeenCalled();
+      const state = store.getState();
+      expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.DOWNLOAD_SOFTWARE_CLICKED);
+      expect(axiosMock.history.put[0].url).toEqual(`${createUpdateAttemptURL}/${softwareDownloadedAttempt.attempt_id}`);
+      expect(axiosMock.history.put[0].data).toEqual(JSON.stringify({ action: 'click_download_software' }));
     });
   });
 
@@ -448,22 +616,41 @@ describe('Data layer integration tests', () => {
     const createdAttempt = Factory.build('attempt', { attempt_status: ExamStatus.CREATED });
     const createdExam = Factory.build('exam', { attempt: createdAttempt });
 
-    it('Should create exam attempt, and update attempt and exam', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam: Factory.build('exam'), active_attempt: {} });
-      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: createdExam, active_attempt: {} });
-      axiosMock.onPost(updateAttemptStatusUrl).reply(200, { exam_attempt_id: createdAttempt.attempt_id });
+    describe('with edx-proctoring as a backend (no EXAMS_BASE_URL)', () => {
+      beforeEach(async () => {
+        mergeConfig({ EXAMS_BASE_URL: null });
+      });
 
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
-      let state = store.getState();
-      expect(state.examState.exam.attempt).toEqual({});
+      it('Should create exam attempt, and update attempt and exam', async () => {
+        axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).replyOnce(200, { exam: Factory.build('exam'), active_attempt: {} });
+        axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).reply(200, { exam: createdExam, active_attempt: {} });
+        axiosMock.onPost(updateAttemptStatusLegacyUrl).reply(200, { exam_attempt_id: createdAttempt.attempt_id });
+
+        await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+        let state = store.getState();
+        expect(state.examState.exam.attempt).toEqual({});
+
+        await executeThunk(thunks.createProctoredExamAttempt(), store.dispatch, store.getState);
+        state = store.getState();
+        expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.CREATED);
+      });
+    });
+
+    it('Should create exam attempt, and update attempt and exam', async () => {
+      await initWithExamAttempt(Factory.build('exam'), {});
+
+      // create thunk should POST attempt and update exam state from backend
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: createdExam });
+      axiosMock.onPost(createUpdateAttemptURL).reply(200, { exam_attempt_id: createdAttempt.attempt_id });
 
       await executeThunk(thunks.createProctoredExamAttempt(), store.dispatch, store.getState);
-      state = store.getState();
+      const state = store.getState();
       expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.CREATED);
+      expect(axiosMock.history.post.length).toBe(1);
     });
 
     it('Should fail to start if no attempt id', async () => {
-      axiosMock.onGet(updateAttemptStatusUrl).reply(200, { exam_attempt_id: createdAttempt.attempt_id });
+      axiosMock.onGet(createUpdateAttemptURL).reply(200, { exam_attempt_id: createdAttempt.attempt_id });
 
       await executeThunk(thunks.createProctoredExamAttempt(), store.dispatch, store.getState);
 
@@ -476,16 +663,40 @@ describe('Data layer integration tests', () => {
     const startedAttempt = Factory.build('attempt', { attempt_status: ExamStatus.STARTED });
     const createdExam = Factory.build('exam', { attempt: createdAttempt });
     const startedExam = Factory.build('exam', { attempt: startedAttempt });
-    const continueAttemptUrl = `${getConfig().LMS_BASE_URL}${BASE_API_URL}/${createdAttempt.attempt_id}`;
+    const continueAttemptLegacyUrl = `${getConfig().LMS_BASE_URL}${BASE_API_URL}/${createdAttempt.attempt_id}`;
+
+    describe('with edx-proctoring as a backend (no EXAMS_BASE_URL)', () => {
+      beforeEach(async () => {
+        mergeConfig({ EXAMS_BASE_URL: null });
+      });
+
+      it('Should start exam, and update attempt and exam', async () => {
+        axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).replyOnce(200, {
+          exam: createdExam, active_attempt: createdAttempt,
+        });
+        axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).reply(200, {
+          exam: startedExam, active_attempt: startedAttempt,
+        });
+        axiosMock.onPost(continueAttemptLegacyUrl).reply(200, { exam_attempt_id: startedAttempt.attempt_id });
+
+        await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+        let state = store.getState();
+        expect(state.examState.activeAttempt.attempt_status).toBe(ExamStatus.CREATED);
+
+        await executeThunk(thunks.startProctoredExam(), store.dispatch, store.getState);
+        state = store.getState();
+        expect(state.examState.activeAttempt).toMatchSnapshot();
+      });
+    });
 
     it('Should start exam, and update attempt and exam', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam: createdExam, active_attempt: createdAttempt });
-      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: startedExam, active_attempt: startedAttempt });
-      axiosMock.onPost(continueAttemptUrl).reply(200, { exam_attempt_id: startedAttempt.attempt_id });
-
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      await initWithExamAttempt(createdExam, createdAttempt);
       let state = store.getState();
       expect(state.examState.activeAttempt.attempt_status).toBe(ExamStatus.CREATED);
+
+      axiosMock.onPost(createUpdateAttemptURL).reply(200, { exam_attempt_id: startedAttempt.attempt_id });
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: startedExam });
+      axiosMock.onGet(latestAttemptURL).reply(200, startedAttempt);
 
       await executeThunk(thunks.startProctoredExam(), store.dispatch, store.getState);
       state = store.getState();
@@ -493,7 +704,7 @@ describe('Data layer integration tests', () => {
     });
 
     it('Should fail to fetch if no exam id', async () => {
-      axiosMock.onPost(continueAttemptUrl).reply(200, { exam_attempt_id: createdAttempt.attempt_id });
+      axiosMock.onPost(createUpdateAttemptURL).reply(200, { exam_attempt_id: createdAttempt.attempt_id });
 
       await executeThunk(thunks.startProctoredExam(), store.dispatch, store.getState);
 
@@ -514,17 +725,12 @@ describe('Data layer integration tests', () => {
       );
       const createdWorkerExam = Factory.build('exam', { attempt: createdWorkerAttempt });
       const startedWorkerExam = Factory.build('exam', { attempt: startedWorkerAttempt });
-      const continueWorkerAttemptUrl = `${getConfig().LMS_BASE_URL}${BASE_API_URL}/${createdWorkerAttempt.attempt_id}`;
 
-      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(
-        200, { exam: createdWorkerExam, active_attempt: createdWorkerAttempt },
-      );
-      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(
-        200, { exam: startedWorkerExam, active_attempt: startedWorkerAttempt },
-      );
-      axiosMock.onPost(continueWorkerAttemptUrl).reply(200, { exam_attempt_id: startedWorkerAttempt.attempt_id });
+      await initWithExamAttempt(createdWorkerExam, createdWorkerAttempt);
+      axiosMock.onPost(createUpdateAttemptURL).reply(200, { exam_attempt_id: startedWorkerAttempt.attempt_id });
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: startedWorkerExam });
+      axiosMock.onGet(latestAttemptURL).reply(200, startedWorkerAttempt);
 
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
       await executeThunk(thunks.startProctoredExam(), store.dispatch, store.getState);
       expect(loggingService.logError).toHaveBeenCalledWith(
         'test error', {
@@ -546,37 +752,66 @@ describe('Data layer integration tests', () => {
     const declinedAttempt = Factory.build('attempt', { attempt_status: ExamStatus.DECLINED });
     const declinedExam = Factory.build('exam', { attempt: declinedAttempt });
 
-    it('Should create exam attempt with declined status, and update attempt and exam', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam: Factory.build('exam'), active_attempt: {} });
-      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: declinedExam, active_attempt: {} });
-      axiosMock.onPost(updateAttemptStatusUrl).reply(200, { exam_attempt_id: declinedAttempt.attempt_id });
+    describe('with edx-proctoring as a backend (no EXAMS_BASE_URL)', () => {
+      beforeEach(async () => {
+        mergeConfig({ EXAMS_BASE_URL: null });
+      });
 
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
-      let state = store.getState();
-      expect(state.examState.exam.attempt).toEqual({});
+      it('Should create exam attempt with declined status, and update attempt and exam', async () => {
+        axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).replyOnce(200, { exam: Factory.build('exam'), active_attempt: {} });
+        axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).reply(200, { exam: declinedExam, active_attempt: {} });
+        axiosMock.onPost(updateAttemptStatusLegacyUrl).reply(200, { exam_attempt_id: declinedAttempt.attempt_id });
 
-      await executeThunk(thunks.skipProctoringExam(), store.dispatch, store.getState);
-      state = store.getState();
-      expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.DECLINED);
+        await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+        let state = store.getState();
+        expect(state.examState.exam.attempt).toEqual({});
+
+        await executeThunk(thunks.skipProctoringExam(), store.dispatch, store.getState);
+        state = store.getState();
+        expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.DECLINED);
+      });
+
+      it('Should change existing attempt status to declined, and update attempt and exam', async () => {
+        axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).replyOnce(200, { exam: createdExam, active_attempt: {} });
+        axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).reply(200, { exam: declinedExam, active_attempt: {} });
+        axiosMock.onPost(updateAttemptStatusLegacyUrl).reply(200, { exam_attempt_id: declinedAttempt.attempt_id });
+
+        await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+        let state = store.getState();
+        expect(state.examState.exam.attempt.attempt_status).toEqual(ExamStatus.CREATED);
+
+        await executeThunk(thunks.skipProctoringExam(), store.dispatch, store.getState);
+        state = store.getState();
+        expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.DECLINED);
+      });
     });
 
-    it('Should change attempt status to declined, and update attempt and exam', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam: createdExam, active_attempt: {} });
+    it('Should create exam attempt with declined status, and update attempt and exam', async () => {
+      await initWithExamAttempt(Factory.build('exam'), {});
       axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: declinedExam, active_attempt: {} });
-      axiosMock.onPost(updateAttemptStatusUrl).reply(200, { exam_attempt_id: declinedAttempt.attempt_id });
+      axiosMock.onPost(createUpdateAttemptURL).reply(200, { exam_attempt_id: declinedAttempt.attempt_id });
 
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      await executeThunk(thunks.skipProctoringExam(), store.dispatch, store.getState);
+      const state = store.getState();
+      expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.DECLINED);
+      expect(axiosMock.history.post.length).toBe(1);
+    });
+
+    it('Should change existing attempt status to declined, and update attempt and exam', async () => {
+      await initWithExamAttempt(createdExam, {});
       let state = store.getState();
       expect(state.examState.exam.attempt.attempt_status).toEqual(ExamStatus.CREATED);
 
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: declinedExam, active_attempt: {} });
+      axiosMock.onPut(`${createUpdateAttemptURL}/${declinedAttempt.attempt_id}`).reply(200, { exam_attempt_id: declinedAttempt.attempt_id });
+
       await executeThunk(thunks.skipProctoringExam(), store.dispatch, store.getState);
       state = store.getState();
       expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.DECLINED);
+      expect(axiosMock.history.put[0].data).toEqual(JSON.stringify({ action: 'decline' }));
     });
 
     it('Should fail to start if no attempt id', async () => {
-      axiosMock.onGet(updateAttemptStatusUrl).reply(200, { exam_attempt_id: declinedAttempt.attempt_id });
-
       await executeThunk(thunks.skipProctoringExam(), store.dispatch, store.getState);
 
       expect(loggingService.logError).toHaveBeenCalled();
@@ -584,33 +819,44 @@ describe('Data layer integration tests', () => {
   });
 
   describe('Test pollAttempt', () => {
-    const pollExamAttemptUrl = `${getConfig().LMS_BASE_URL}${attempt.exam_started_poll_url}`;
+    describe('with edx-proctoring as a backend (no EXAMS_BASE_URL)', () => {
+      const pollExamAttemptUrl = `${getConfig().LMS_BASE_URL}${attempt.exam_started_poll_url}`;
+      beforeEach(async () => {
+        mergeConfig({ EXAMS_BASE_URL: null });
+      });
 
-    it('Should poll exam attempt, and update attempt and exam', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam, active_attempt: attempt });
-      axiosMock.onGet(pollExamAttemptUrl).reply(200, {
+      it('Should poll and update active attempt', async () => {
+        axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).replyOnce(200, { exam, active_attempt: attempt });
+        axiosMock.onGet(pollExamAttemptUrl).reply(200, {
+          time_remaining_seconds: 1739.9,
+          accessibility_time_string: 'you have 29 minutes remaining',
+          attempt_status: ExamStatus.STARTED,
+        });
+
+        await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+        let state = store.getState();
+        expect(state.examState.exam.attempt).toMatchSnapshot();
+
+        await executeThunk(thunks.pollAttempt(attempt.exam_started_poll_url), store.dispatch, store.getState);
+        state = store.getState();
+        const expectedPollUrl = `${getConfig().LMS_BASE_URL}${attempt.exam_started_poll_url}`;
+        expect(state.examState.exam.attempt).toMatchSnapshot();
+        expect(axiosMock.history.get[1].url).toEqual(expectedPollUrl);
+      });
+    });
+
+    it('Should poll and update active attempt', async () => {
+      await initWithExamAttempt(exam, attempt);
+
+      axiosMock.onGet(latestAttemptURL).reply(200, {
         time_remaining_seconds: 1739.9,
         accessibility_time_string: 'you have 29 minutes remaining',
         attempt_status: ExamStatus.STARTED,
       });
 
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
-      let state = store.getState();
-      expect(state.examState.exam.attempt).toMatchSnapshot();
-
       await executeThunk(thunks.pollAttempt(attempt.exam_started_poll_url), store.dispatch, store.getState);
-      state = store.getState();
-      expect(state.examState.exam.attempt).toMatchSnapshot();
-    });
-
-    it('Should fail to start if no attempt id', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam, active_attempt: attempt });
-      axiosMock.onGet(pollExamAttemptUrl).networkError();
-
-      await executeThunk(thunks.pollAttempt(attempt.exam_started_poll_url), store.dispatch, store.getState);
-
       const state = store.getState();
-      expect(state.examState.apiErrorMsg).toBe('Network Error');
+      expect(state.examState.activeAttempt).toMatchSnapshot();
     });
   });
 
@@ -620,12 +866,9 @@ describe('Data layer integration tests', () => {
         'attempt', { attempt_status: ExamStatus.STARTED, desktop_application_js_url: 'http://proctortest.com' },
       );
       const startedWorkerExam = Factory.build('exam', { attempt: startedWorkerAttempt });
-      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(
-        200, { exam: startedWorkerExam, active_attempt: startedWorkerAttempt },
-      );
-      axiosMock.onPut(updateAttemptStatusUrl).reply(200, { exam_attempt_id: startedWorkerAttempt.attempt_id });
+      await initWithExamAttempt(startedWorkerExam, startedWorkerAttempt);
 
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      axiosMock.onPut(`${createUpdateAttemptURL}/${startedWorkerAttempt.attempt_id}`).reply(200, { exam_attempt_id: startedWorkerAttempt.attempt_id });
       await executeThunk(thunks.pingAttempt(), store.dispatch, store.getState);
 
       expect(loggingService.logError).toHaveBeenCalledWith(
@@ -637,7 +880,6 @@ describe('Data layer integration tests', () => {
         },
       );
       const request = axiosMock.history.put[0];
-      expect(request.url).toEqual(updateAttemptStatusUrl);
       expect(request.data).toEqual(JSON.stringify({
         action: 'error',
         detail: 'test error',
@@ -646,55 +888,63 @@ describe('Data layer integration tests', () => {
   });
 
   describe('Test getLatestAttemptData', () => {
+    describe('with edx-proctoring as a backend (no EXAMS_BASE_URL)', () => {
+      beforeEach(async () => {
+        mergeConfig({ EXAMS_BASE_URL: null });
+      });
+
+      it('Should get, and save latest attempt', async () => {
+        const attemptDataUrl = `${getConfig().LMS_BASE_URL}${BASE_API_URL}/course_id/${courseId}?is_learning_mfe=true`;
+        axiosMock.onGet(attemptDataUrl)
+          .reply(200, {
+            exam: {},
+            active_attempt: attempt,
+          });
+
+        await executeThunk(thunks.getLatestAttemptData(courseId), store.dispatch);
+
+        const state = store.getState();
+        expect(state)
+          .toMatchSnapshot();
+      });
+    });
+
     it('Should get, and save latest attempt', async () => {
-      const attemptDataUrl = `${getConfig().LMS_BASE_URL}${BASE_API_URL}/course_id/${courseId}?is_learning_mfe=true`;
-      axiosMock.onGet(attemptDataUrl)
-        .reply(200, {
-          exam: {},
-          active_attempt: attempt,
-        });
+      await initWithExamAttempt();
+
+      axiosMock.onGet(latestAttemptURL).reply(200, Factory.build('attempt', { attempt_id: 1234 }));
 
       await executeThunk(thunks.getLatestAttemptData(courseId), store.dispatch);
 
       const state = store.getState();
-      expect(state)
-        .toMatchSnapshot();
+      expect(state.examState.activeAttempt.attempt_id).toEqual(1234);
     });
   });
 
-  describe('Test examRequiresAccessToken without exams url', () => {
-    it('Should not fetch exam access token', async () => {
-      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam, active_attempt: attempt });
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
-      await executeThunk(thunks.examRequiresAccessToken(), store.dispatch, store.getState);
+  describe('Test examRequiresAccessToken', () => {
+    const fetchExamAccessUrl = `${getConfig().EXAMS_BASE_URL}/api/v1/access_tokens/exam_id/${exam.id}/`;
 
-      const state = store.getState();
-      expect(state.examState.exam.id).toBe(exam.id);
-      expect(state.examState.examAccessToken.exam_access_token).toBe('');
-    });
-  });
+    describe('with edx-proctoring as a backend (no EXAMS_BASE_URL)', () => {
+      beforeEach(async () => {
+        mergeConfig({ EXAMS_BASE_URL: null });
+      });
 
-  describe('Test examRequiresAccessToken for exams IDA url', () => {
-    beforeAll(async () => {
-      mergeConfig({
-        EXAMS_BASE_URL: process.env.EXAMS_BASE_URL || null,
+      it('Should not fetch exam access token', async () => {
+        axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).reply(200, { exam, active_attempt: attempt });
+        await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+        await executeThunk(thunks.examRequiresAccessToken(), store.dispatch, store.getState);
+
+        const state = store.getState();
+        expect(state.examState.exam.id).toBe(exam.id);
+        expect(state.examState.examAccessToken.exam_access_token).toBe('');
       });
     });
 
     it('Should get exam access token', async () => {
-      const createExamAttemptURL = `${getConfig().EXAMS_BASE_URL}/api/v1/exams/attempt`;
-      const examURL = `${getConfig().EXAMS_BASE_URL}/api/v1/student/exam/attempt/course_id/${courseId}/content_id/${contentId}`;
-      const activeAttemptURL = `${getConfig().EXAMS_BASE_URL}/api/v1/exams/attempt/latest`;
-      const fetchExamAccessUrl = `${getConfig().EXAMS_BASE_URL}/api/v1/access_tokens/exam_id/${exam.id}/`;
       const examAccessToken = Factory.build('examAccessToken');
 
-      axiosMock.onGet(examURL).reply(200, { exam });
-      axiosMock.onGet(activeAttemptURL).reply(200, {});
-      axiosMock.onPost(createExamAttemptURL).reply(200, { exam_attempt_id: 1111111 });
+      await initWithExamAttempt();
       axiosMock.onGet(fetchExamAccessUrl).reply(200, examAccessToken);
-
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
-      await executeThunk(thunks.startTimedExam(), store.dispatch, store.getState);
       await executeThunk(thunks.examRequiresAccessToken(), store.dispatch, store.getState);
 
       const state = store.getState();
@@ -702,7 +952,6 @@ describe('Data layer integration tests', () => {
     });
 
     it('Should fail to fetch if no exam id', async () => {
-      const fetchExamAccessUrl = `${getConfig().EXAMS_BASE_URL}/api/v1/access_tokens/exam_id/${exam.id}/`;
       axiosMock.onGet(fetchExamAccessUrl).reply(200, {});
       await executeThunk(thunks.examRequiresAccessToken(), store.dispatch, store.getState);
 
@@ -711,173 +960,39 @@ describe('Data layer integration tests', () => {
     });
 
     it('Should fail to fetch if API error occurs', async () => {
-      const createExamAttemptURL = `${getConfig().EXAMS_BASE_URL}/api/v1/exams/attempt`;
-      const examURL = `${getConfig().EXAMS_BASE_URL}/api/v1/student/exam/attempt/course_id/${courseId}/content_id/${contentId}`;
-      const activeAttemptURL = `${getConfig().EXAMS_BASE_URL}/api/v1/exams/attempt/latest`;
-      const fetchExamAccessUrl = `${getConfig().EXAMS_BASE_URL}/api/v1/access_tokens/exam_id/${exam.id}/`;
-
-      axiosMock.onGet(examURL).reply(200, { exam });
-      axiosMock.onGet(activeAttemptURL).reply(200, {});
-      axiosMock.onPost(createExamAttemptURL).reply(200, { exam_attempt_id: 1111111 });
+      await initWithExamAttempt();
       axiosMock.onGet(fetchExamAccessUrl).reply(400, { detail: 'Exam access token not granted' });
 
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
-      await executeThunk(thunks.startTimedExam(), store.dispatch, store.getState);
       await executeThunk(thunks.examRequiresAccessToken(), store.dispatch, store.getState);
 
       const state = store.getState();
       expect(state.examState.examAccessToken.exam_access_token).toBe('');
     });
   });
-
-  describe('Test exams IDA url', () => {
-    beforeAll(async () => {
-      mergeConfig({
-        EXAMS_BASE_URL: process.env.EXAMS_BASE_URL || null,
-      });
-    });
-
-    it('Should call the exams service for create attempt', async () => {
-      const createExamAttemptURL = `${getConfig().EXAMS_BASE_URL}/api/v1/exams/attempt`;
-      const examURL = `${getConfig().EXAMS_BASE_URL}/api/v1/student/exam/attempt/course_id/${courseId}/content_id/${contentId}`;
-      const activeAttemptURL = `${getConfig().EXAMS_BASE_URL}/api/v1/exams/attempt/latest`;
-
-      axiosMock.onGet(examURL)
-        .reply(200, { exam });
-      axiosMock.onGet(activeAttemptURL)
-        .reply(200, {});
-      axiosMock.onPost(createExamAttemptURL)
-        .reply(200, { exam_attempt_id: 1111111 });
-
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
-      await executeThunk(thunks.startTimedExam(), store.dispatch, store.getState);
-
-      expect(axiosMock.history.post[0].url)
-        .toEqual(createExamAttemptURL);
-    });
-
-    it('Should call the exams service for update attempt', async () => {
-      const updateExamAttemptURL = `${getConfig().EXAMS_BASE_URL}/api/v1/exams/attempt/${attempt.id}`;
-      const examURL = `${getConfig().EXAMS_BASE_URL}/api/v1/student/exam/attempt/course_id/${courseId}/content_id/${contentId}`;
-      const activeAttemptURL = `${getConfig().EXAMS_BASE_URL}/api/v1/exams/attempt/latest`;
-
-      axiosMock.onGet(examURL).reply(200, { exam });
-      axiosMock.onGet(activeAttemptURL).reply(200, { attempt });
-      axiosMock.onPut(updateExamAttemptURL).reply(200, { exam_attempt_id: attempt.id });
-
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
-      await executeThunk(thunks.stopExam(), store.dispatch, store.getState);
-      expect(axiosMock.history.put[0].url)
-        .toEqual(updateExamAttemptURL);
-    });
-
-    it('Should call the exams service to fetch attempt data', async () => {
-      const examURL = `${getConfig().EXAMS_BASE_URL}/api/v1/student/exam/attempt/course_id/${courseId}/content_id/${contentId}`;
-      const activeAttemptURL = `${getConfig().EXAMS_BASE_URL}/api/v1/exams/attempt/latest`;
-
-      axiosMock.onGet(examURL).reply(200, { exam });
-      axiosMock.onGet(activeAttemptURL).reply(200, attempt);
-
-      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
-
-      expect(axiosMock.history.get[0].url)
-        .toEqual(examURL);
-      expect(axiosMock.history.get[1].url)
-        .toEqual(activeAttemptURL);
-
-      const state = store.getState();
-      expect(state)
-        .toMatchSnapshot();
-    });
-
-    it('Should call the exams service to get latest attempt data', async () => {
-      const activeAttemptURL = `${getConfig().EXAMS_BASE_URL}/api/v1/exams/attempt/latest`;
-
-      // Updated attempt with changed status
-      const updatedAttempt = Factory.build('attempt', { attempt_status: ExamStatus.READY_TO_SUBMIT });
-
-      // Get initial data first, then updated data when calling pollAttempt
-      axiosMock.onGet(activeAttemptURL).replyOnce(200, attempt);
-      axiosMock.onGet(activeAttemptURL).reply(200, updatedAttempt);
-
-      // Get data, initialize state
-      await executeThunk(thunks.getLatestAttemptData(courseId), store.dispatch);
-      const beforeState = store.getState();
-      expect(beforeState.examState.activeAttempt).toEqual(attempt);
-
-      // Poll with initialized state
-      const dummyURL = `${getConfig().EXAMS_BASE_URL}/edx-proctoring/dummy-url`;
-      await executeThunk(thunks.pollAttempt(dummyURL), store.dispatch, store.getState);
-      const afterState = store.getState();
-      expect(afterState.examState.activeAttempt).toEqual(updatedAttempt);
-
-      expect(axiosMock.history.get[0].url).toEqual(activeAttemptURL);
-      expect(axiosMock.history.get[1].url).toEqual(activeAttemptURL);
-
-      expect(afterState).toMatchSnapshot();
-      expect(beforeState).not.toEqual(afterState); // Test that the state was updated when polled
-    });
-  });
 });
 
-describe('External API integration tests', () => {
-  let store;
+// TODO: This needs it's own test file
+// describe('External API integration tests', () => {
+//   let store;
 
-  describe('Test isExam', () => {
-    it('Should return false if exam is not set', async () => {
-      expect(isExam()).toBe(false);
-    });
-  });
+//   describe('Test isExam', () => {
+//     it('Should return false if exam is not set', async () => {
+//       expect(isExam()).toBe(false);
+//     });
+//   });
 
-  describe('Test getExamAccess', () => {
-    it('Should return empty string if no access token', async () => {
-      expect(getExamAccess()).toBe('');
-    });
-  });
+//   describe('Test getExamAccess', () => {
+//     it('Should return empty string if no access token', async () => {
+//       expect(getExamAccess()).toBe('');
+//     });
+//   });
 
-  describe('Test fetchExamAccess', () => {
-    beforeAll(async () => {
-      mergeConfig({
-        EXAMS_BASE_URL: process.env.EXAMS_BASE_URL || null,
-      });
-    });
-
-    it('Should dispatch get exam access token', async () => {
-      const mockDispatch = jest.fn(() => store.dispatch);
-      const mockState = jest.fn(() => store.getState);
-      const dispatchReturn = fetchExamAccess(mockDispatch, mockState);
-      expect(dispatchReturn).toBeInstanceOf(Promise);
-    });
-  });
-});
-
-describe('External API integration tests', () => {
-  let store;
-
-  describe('Test isExam', () => {
-    it('Should return false if exam is not set', async () => {
-      expect(isExam()).toBe(false);
-    });
-  });
-
-  describe('Test getExamAccess', () => {
-    it('Should return empty string if no access token', async () => {
-      expect(getExamAccess()).toBe('');
-    });
-  });
-
-  describe('Test fetchExamAccess', () => {
-    beforeAll(async () => {
-      mergeConfig({
-        EXAMS_BASE_URL: process.env.EXAMS_BASE_URL || null,
-      });
-    });
-
-    it('Should dispatch get exam access token', async () => {
-      const mockDispatch = jest.fn(() => store.dispatch);
-      const mockState = jest.fn(() => store.getState);
-      const dispatchReturn = fetchExamAccess(mockDispatch, mockState);
-      expect(dispatchReturn).toBeInstanceOf(Promise);
-    });
-  });
-});
+//   describe('Test fetchExamAccess', () => {
+//     it('Should dispatch get exam access token', async () => {
+//       const mockDispatch = jest.fn(() => store.dispatch);
+//       const mockState = jest.fn(() => store.getState);
+//       const dispatchReturn = fetchExamAccess(mockDispatch, mockState);
+//       expect(dispatchReturn).toBeInstanceOf(Promise);
+//     });
+//   });
+// });

--- a/src/data/redux.test.jsx
+++ b/src/data/redux.test.jsx
@@ -223,6 +223,9 @@ describe('Data layer integration tests', () => {
     });
 
     it('Should fail to fetch if no exam id', async () => {
+      // TODO: For working in these tests in the future
+      // This error logic is common to every thunk, so we can refactor this out and test it separately
+      // instead of repeating it for every feature.
       axiosMock.onPost(createUpdateAttemptURL).reply(200, { exam_attempt_id: attempt.attempt_id });
 
       await executeThunk(thunks.startTimedExam(), store.dispatch, store.getState);
@@ -507,6 +510,9 @@ describe('Data layer integration tests', () => {
     });
 
     it('Should fail to fetch if no attempt id', async () => {
+      // TODO: For working in these tests in the future
+      // This error logic is common to every thunk, so we can refactor this out and test it separately
+      // instead of repeating it for every feature.
       await initWithExamAttempt(Factory.build('exam'), {});
 
       await executeThunk(thunks.submitExam(), store.dispatch, store.getState);

--- a/src/data/redux.test.jsx
+++ b/src/data/redux.test.jsx
@@ -191,6 +191,11 @@ describe('Data layer integration tests', () => {
         await executeThunk(thunks.startTimedExam(), store.dispatch, store.getState);
         state = store.getState();
         expect(state.examState.activeAttempt).toMatchSnapshot();
+        expect(axiosMock.history.post[0].data).toEqual(JSON.stringify({
+          exam_id: exam.id,
+          start_clock: 'true',
+          attempt_proctored: 'false',
+        }));
       });
     });
 

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -1,7 +1,7 @@
 import 'babel-polyfill';
 import '@testing-library/jest-dom';
 import './data/__factories__';
-import { getConfig } from '@edx/frontend-platform';
+import { getConfig, mergeConfig } from '@edx/frontend-platform';
 import { configure as configureLogging } from '@edx/frontend-platform/logging';
 import { configure as configureAuth, MockAuthService } from '@edx/frontend-platform/auth';
 import { AppContext } from '@edx/frontend-platform/react';
@@ -24,7 +24,14 @@ class MockLoggingService {
   }
 }
 
+export function initializeTestConfig() {
+  mergeConfig({
+    EXAMS_BASE_URL: process.env.EXAMS_BASE_URL || null,
+  });
+}
+
 export function initializeMockApp() {
+  initializeTestConfig();
   const loggingService = configureLogging(MockLoggingService, {
     config: getConfig(),
   });


### PR DESCRIPTION
### [MST-1831](https://2u-internal.atlassian.net/browse/MST-1831)

Whenever an exam attempt endpoint is hit (create/update) this will first check if that exam has a property indicating it is managed by edx-proctoring instead of edx-exams. If so, route the request there.

When writing out tests for this I noticed that almost none of our test cases are running against a version of the app with EXAMS_BASE_URL set. Since that's the direction we're headed I've made that the default and added an extra test case to each thunk to validate the old integration is still working. I fixed a few issues with the existing tests but there's still work that could be done. This took a ton of lines because of how these tests are structured. A bigger refactor could eliminate o lot code in here but I didn't want to re-invent too many things at once so I stuck with the existing structure as best I could.