### PR TITLE
feat: add null state check

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -2,15 +2,22 @@ import { examRequiresAccessToken, store } from './data';
 
 export function isExam() {
   const { exam } = store.getState().examState;
-  return exam.id !== null;
+  return !!exam?.id;
 }
 
 export function getExamAccess() {
-  const { examAccessToken } = store.getState().examState;
+  const { exam, examAccessToken } = store.getState().examState;
+  if (!exam) {
+    return '';
+  }
   return examAccessToken.exam_access_token;
 }
 
 export async function fetchExamAccess() {
+  const { exam } = store.getState().examState;
   const { dispatch } = store;
+  if (!exam) {
+    return Promise.resolve();
+  }
   return dispatch(examRequiresAccessToken());
 }

--- a/src/api.test.jsx
+++ b/src/api.test.jsx
@@ -1,25 +1,59 @@
+import { Factory } from 'rosie';
+
 import { isExam, getExamAccess, fetchExamAccess } from './api';
+import { store } from './data';
 
 describe('External API integration tests', () => {
-  let store;
+  describe('Test isExam with exam', () => {
+    beforeAll(() => {
+      jest.mock('./data');
+      const mockExam = Factory.build('exam', { attempt: Factory.build('attempt') });
+      const mockToken = Factory.build('examAccessToken');
+      const mockState = { examState: { exam: mockExam, examAccessToken: mockToken } };
+      store.getState = jest.fn().mockReturnValue(mockState);
+    });
 
-  describe('Test isExam', () => {
-    it('Should return false if exam is not set', async () => {
+    afterAll(() => {
+      jest.clearAllMocks();
+      jest.resetAllMocks();
+    });
+
+    it('isExam should return true if exam is set', () => {
+      expect(isExam()).toBe(true);
+    });
+
+    it('getExamAccess should return exam access token if access token', () => {
+      expect(getExamAccess()).toBeTruthy();
+    });
+
+    it('fetchExamAccess should dispatch get exam access token', () => {
+      const dispatchReturn = fetchExamAccess();
+      expect(dispatchReturn).toBeInstanceOf(Promise);
+    });
+  });
+
+  describe('Test isExam without exam', () => {
+    beforeAll(() => {
+      jest.mock('./data');
+      const mockState = { examState: { exam: null, examAccessToken: null } };
+      store.getState = jest.fn().mockReturnValue(mockState);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+      jest.resetAllMocks();
+    });
+
+    it('isExam should return false if exam is not set', () => {
       expect(isExam()).toBe(false);
     });
-  });
 
-  describe('Test getExamAccess', () => {
-    it('Should return empty string if no access token', async () => {
-      expect(getExamAccess()).toBe('');
+    it('getExamAccess should return empty string if exam access token not set', () => {
+      expect(getExamAccess()).toBeFalsy();
     });
-  });
 
-  describe('Test fetchExamAccess', () => {
-    it('Should dispatch get exam access token', async () => {
-      const mockDispatch = jest.fn(() => store.dispatch);
-      const mockState = jest.fn(() => store.getState);
-      const dispatchReturn = fetchExamAccess(mockDispatch, mockState);
+    it('fetchExamAccess should not dispatch get exam access token', () => {
+      const dispatchReturn = fetchExamAccess();
       expect(dispatchReturn).toBeInstanceOf(Promise);
     });
   });


### PR DESCRIPTION
Part of [MST-1599](https://2u-internal.atlassian.net/browse/MST-1599).

Based on feedback from [this PR](https://github.com/openedx/frontend-app-learning/pull/1083) to fetch exam access token, we want to handle the null case when there is no exam. Thus the api functions here should include a null check to handle this.