### PR TITLE
feat: update URL for provider settings

### DIFF
--- a/src/data/__snapshots__/redux.test.jsx.snap
+++ b/src/data/__snapshots__/redux.test.jsx.snap
@@ -167,6 +167,22 @@ Object {
 }
 `;
 
+exports[`Data layer integration tests Test getProctoringSettings Test legacy URL for getProctoringSettings Should get, and save proctoringSettings 1`] = `
+Object {
+  "exam_proctoring_backend": Object {
+    "download_url": "",
+    "instructions": Array [],
+    "name": "",
+    "rules": Object {},
+  },
+  "integration_specific_email": "",
+  "learner_notification_from_email": "",
+  "provider_name": "",
+  "provider_tech_support_email": "",
+  "provider_tech_support_phone": "",
+}
+`;
+
 exports[`Data layer integration tests Test pollAttempt Should poll and update active attempt 1`] = `
 Object {
   "attempt_code": "",

--- a/src/data/api.js
+++ b/src/data/api.js
@@ -139,8 +139,13 @@ export async function fetchExamReviewPolicy(examId) {
   return data;
 }
 
-export async function fetchProctoringSettings(examId) {
-  const url = new URL(`${getConfig().LMS_BASE_URL}/api/edx_proctoring/v1/proctored_exam/settings/exam_id/${examId}/`);
+export async function fetchProctoringSettings(courseId, examId) {
+  let url;
+  if (!getConfig().EXAMS_BASE_URL) {
+    url = new URL(`${getConfig().LMS_BASE_URL}/api/edx_proctoring/v1/proctored_exam/settings/exam_id/${examId}/`);
+  } else {
+    url = new URL(`${getConfig().EXAMS_BASE_URL}/api/v1/exam/provider_settings/course_id/${courseId}/exam_id/${examId}`);
+  }
   const { data } = await getAuthenticatedHttpClient().get(url.href);
   return data;
 }

--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -110,7 +110,7 @@ export function getProctoringSettings() {
       return;
     }
     try {
-      const proctoringSettings = await fetchProctoringSettings(exam.id);
+      const proctoringSettings = await fetchProctoringSettings(exam.course_id, exam.id);
       dispatch(setProctoringSettings({ proctoringSettings }));
     } catch (error) {
       handleAPIError(error, dispatch);


### PR DESCRIPTION
## [MST-1863](https://2u-internal.atlassian.net/browse/MST-1863)

If the `EXAMS_BASE_URL` config settings is available, the frontend should call the exams service to retrieve provider related settings.