### PR TITLE
feat: start lti proctoring software

### DIFF
--- a/src/instructions/Instructions.test.jsx
+++ b/src/instructions/Instructions.test.jsx
@@ -792,7 +792,7 @@ describe('SequenceExamWrapper', () => {
     await waitFor(() => { expect(windowSpy).toHaveBeenCalledWith('http://localhost:18740/lti/start_proctoring/4321', '_blank'); });
   });
 
-  it('Shows correct download instructions for legacy provider if attempt status is created', () => {
+  it('Shows correct download instructions for legacy rest provider if attempt status is created', () => {
     const instructions = [
       'instruction 1',
       'instruction 2',
@@ -838,6 +838,41 @@ describe('SequenceExamWrapper', () => {
     instructions.forEach((instruction) => {
       expect(screen.getByText(instruction)).toBeInTheDocument();
     });
+  });
+
+  it('Shows correct download instructions for legacy rpnow provider if attempt status is created', () => {
+    store.getState = () => ({
+      examState: Factory.build('examState', {
+        activeAttempt: {},
+        proctoringSettings: Factory.build('proctoringSettings', {
+          provider_name: 'Provider Name',
+          exam_proctoring_backend: {},
+        }),
+        exam: Factory.build('exam', {
+          is_proctored: true,
+          type: ExamType.PROCTORED,
+          use_legacy_attempt_api: true,
+          attempt: Factory.build('attempt', {
+            attempt_status: ExamStatus.CREATED,
+            attempt_code: '1234-5678-9012-3456',
+            use_legacy_attempt_api: true,
+          }),
+        }),
+      }),
+    });
+
+    render(
+      <ExamStateProvider>
+        <Instructions>
+          <div>Sequence</div>
+        </Instructions>
+      </ExamStateProvider>,
+      { store },
+    );
+    expect(screen.getByDisplayValue('1234-5678-9012-3456')).toBeInTheDocument();
+    expect(screen.getByText('For security and exam integrity reasons, '
+      + 'we ask you to sign in to your edX account. Then we will '
+      + 'direct you to the RPNow proctoring experience.')).toBeInTheDocument();
   });
 
   it('Shows error message if receives unknown attempt status', () => {

--- a/src/instructions/proctored_exam/download-instructions/LtiProviderInstructions.jsx
+++ b/src/instructions/proctored_exam/download-instructions/LtiProviderInstructions.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+
+const LtiProviderExamInstructions = ({
+  providerName, supportEmail, supportPhone,
+}) => (
+  <>
+    <p>
+      <FormattedMessage
+        id="exam.DownloadSoftwareProctoredExamInstructions.text1"
+        defaultMessage={'Note: As part of the proctored exam setup, you '
+        + 'will be asked to verify your identity. Before you begin, make '
+        + 'sure you are on a computer with a webcam, and that you have a '
+        + 'valid form of photo identification such as a driver’s license or passport.'}
+      />
+    </p>
+    {supportEmail && supportPhone && (
+      <p>
+        <FormattedMessage
+          id="exam.DownloadSoftwareProctoredExamInstructions.supportText"
+          defaultMessage={'If you have issues relating to proctoring, you can contact '
+          + '{providerName} technical support by emailing {supportEmail} or by calling {supportPhone}.'}
+          values={{
+            providerName,
+            supportEmail,
+            supportPhone,
+          }}
+        />
+      </p>
+    )}
+  </>
+);
+
+LtiProviderExamInstructions.propTypes = {
+  providerName: PropTypes.string,
+  supportEmail: PropTypes.string,
+  supportPhone: PropTypes.string,
+};
+
+LtiProviderExamInstructions.defaultProps = {
+  providerName: '',
+  supportEmail: '',
+  supportPhone: '',
+};
+
+export default LtiProviderExamInstructions;

--- a/src/instructions/proctored_exam/download-instructions/RPNowInstructions.jsx
+++ b/src/instructions/proctored_exam/download-instructions/RPNowInstructions.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import ExamCode from './ExamCode';
 
-const DefaultInstructions = ({ code }) => (
+const RPNowInstructions = ({ code }) => (
   <>
     <div className="h4">
       <FormattedMessage
@@ -55,8 +55,8 @@ const DefaultInstructions = ({ code }) => (
   </>
 );
 
-DefaultInstructions.propTypes = {
+RPNowInstructions.propTypes = {
   code: PropTypes.string.isRequired,
 };
 
-export default DefaultInstructions;
+export default RPNowInstructions;

--- a/src/instructions/proctored_exam/download-instructions/RestProviderInstructions.jsx
+++ b/src/instructions/proctored_exam/download-instructions/RestProviderInstructions.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 
-const ProviderProctoredExamInstructions = ({
+const RestProviderInstructions = ({
   providerName, supportEmail, supportPhone, instructions,
 }) => (
   <>
@@ -39,17 +39,17 @@ const ProviderProctoredExamInstructions = ({
   </>
 );
 
-ProviderProctoredExamInstructions.propTypes = {
+RestProviderInstructions.propTypes = {
   providerName: PropTypes.string,
   supportEmail: PropTypes.string,
   supportPhone: PropTypes.string,
   instructions: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
-ProviderProctoredExamInstructions.defaultProps = {
+RestProviderInstructions.defaultProps = {
   providerName: '',
   supportEmail: '',
   supportPhone: '',
 };
 
-export default ProviderProctoredExamInstructions;
+export default RestProviderInstructions;

--- a/src/instructions/proctored_exam/download-instructions/index.jsx
+++ b/src/instructions/proctored_exam/download-instructions/index.jsx
@@ -126,7 +126,7 @@ const DownloadSoftwareProctoredExamInstructions = ({ intl, skipProctoredExam }) 
           onStartExamClick={handleStartExamClick}
           downloadClicked={downloadClicked}
         />
-        {!LtiProviderExamInstructions && !withProviderInstructions && (
+        {!examHasLtiProvider && !withProviderInstructions && (
           <div className="pt-3">
             <div className="h4">
               <FormattedMessage

--- a/src/instructions/proctored_exam/download-instructions/index.jsx
+++ b/src/instructions/proctored_exam/download-instructions/index.jsx
@@ -1,5 +1,6 @@
 import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
+import { getConfig } from '@edx/frontend-platform';
 import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Container } from '@edx/paragon';
 import ExamStateContext from '../../../context';
@@ -7,8 +8,9 @@ import { ExamStatus } from '../../../constants';
 import WarningModal from '../WarningModal';
 import { pollExamAttempt, softwareDownloadAttempt } from '../../../data/api';
 import messages from '../messages';
-import ProviderInstructions from './ProviderInstructions';
-import DefaultInstructions from './DefaultInstructions';
+import LtiProviderExamInstructions from './LtiProviderInstructions';
+import RestProviderInstructions from './RestProviderInstructions';
+import RPNowInstructions from './RPNowInstructions';
 import DownloadButtons from './DownloadButtons';
 import Footer from '../Footer';
 import SkipProctoredExamButton from '../SkipProctoredExamButton';
@@ -31,6 +33,7 @@ const DownloadSoftwareProctoredExamInstructions = ({ intl, skipProctoredExam }) 
     attempt_code: examCode,
     attempt_id: attemptId,
     software_download_url: downloadUrl,
+    use_legacy_attempt_api: useLegacyAttemptApi,
   } = attempt;
   const {
     provider_name: providerName,
@@ -38,10 +41,13 @@ const DownloadSoftwareProctoredExamInstructions = ({ intl, skipProctoredExam }) 
     provider_tech_support_phone: supportPhone,
     exam_proctoring_backend: proctoringBackend,
   } = proctoringSettings;
+  const examHasLtiProvider = !useLegacyAttemptApi;
   const { instructions } = proctoringBackend || {};
   const [systemCheckStatus, setSystemCheckStatus] = useState('');
   const [downloadClicked, setDownloadClicked] = useState(false);
   const withProviderInstructions = instructions && instructions.length > 0;
+  const launchSoftwareUrl = examHasLtiProvider
+    ? `${getConfig().EXAMS_BASE_URL}/lti/start_proctoring/${attemptId}` : downloadUrl;
 
   const handleDownloadClick = () => {
     pollExamAttempt(`${pollUrl}?sourceid=instructions`)
@@ -50,20 +56,45 @@ const DownloadSoftwareProctoredExamInstructions = ({ intl, skipProctoredExam }) 
           setSystemCheckStatus('success');
         } else {
           softwareDownloadAttempt(attemptId);
-          window.open(downloadUrl, '_blank');
+          window.open(launchSoftwareUrl, '_blank');
         }
       });
     setDownloadClicked(true);
   };
 
   const handleStartExamClick = () => {
-    pollExamAttempt(`${attempt.exam_started_poll_url}?sourceid=instructions`)
+    pollExamAttempt(`${pollUrl}?sourceid=instructions`)
       .then((data) => (
         data.status === ExamStatus.READY_TO_START
           ? getExamAttemptsData(courseId, sequenceId)
           : setSystemCheckStatus('failure')
       ));
   };
+
+  function providerInstructions() {
+    if (examHasLtiProvider) {
+      return (
+        <LtiProviderExamInstructions
+          providerName={providerName}
+          supportEmail={supportEmail}
+          supportPhone={supportPhone}
+        />
+      );
+    }
+    if (withProviderInstructions) {
+      return (
+        <RestProviderInstructions
+          providerName={providerName}
+          supportEmail={supportEmail}
+          supportPhone={supportPhone}
+          instructions={instructions}
+        />
+      );
+    }
+    return (
+      <RPNowInstructions code={examCode} />
+    );
+  }
 
   return (
     <div>
@@ -88,23 +119,14 @@ const DownloadSoftwareProctoredExamInstructions = ({ intl, skipProctoredExam }) 
             defaultMessage="Set up and start your proctored exam."
           />
         </div>
-        {withProviderInstructions
-          ? (
-            <ProviderInstructions
-              providerName={providerName}
-              supportEmail={supportEmail}
-              supportPhone={supportPhone}
-              instructions={instructions}
-            />
-          )
-          : <DefaultInstructions code={examCode} />}
+        { providerInstructions() }
         <DownloadButtons
-          downloadUrl={downloadUrl}
+          downloadUrl={launchSoftwareUrl}
           onDownloadClick={handleDownloadClick}
           onStartExamClick={handleStartExamClick}
           downloadClicked={downloadClicked}
         />
-        {!withProviderInstructions && (
+        {!LtiProviderExamInstructions && !withProviderInstructions && (
           <div className="pt-3">
             <div className="h4">
               <FormattedMessage


### PR DESCRIPTION
### [MST-1841](https://2u-internal.atlassian.net/browse/MST-1841)

Adds a new interstitial for downloading/launching an LTI based proctoring tool. This is more or the the same content as the existing page but having a separate template will allow these instructions to deviate from what we have today as needed.

I did a bit of name refactoring to make it clear what download page is used in what case. 'Default' was a bit misleading because that UI is actually specific to RPNow. 