### PR TITLE
fix: bump peer dependency version for frontend-platform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "semantic-release": "17.2.3"
       },
       "peerDependencies": {
-        "@edx/frontend-platform": "^2.3.0 || ^3.0.0",
+        "@edx/frontend-platform": "^4.2.0",
         "@edx/paragon": "^19.4.1 || ^20.22.4",
         "@reduxjs/toolkit": "^1.5.1",
         "prop-types": "^15.7.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eventemitter3": "^4.0.7"
   },
   "peerDependencies": {
-    "@edx/frontend-platform": "^2.3.0 || ^3.0.0",
+    "@edx/frontend-platform": "^4.2.0",
     "@edx/paragon": "^19.4.1 || ^20.22.4",
     "@reduxjs/toolkit": "^1.5.1",
     "prop-types": "^15.7.2",


### PR DESCRIPTION
Left out `frontend-platform` upgrade from dev dependencies, so also bump version there.