### PR TITLE
fix: missing legacy flag on download attempt call

### DIFF
--- a/src/instructions/Instructions.test.jsx
+++ b/src/instructions/Instructions.test.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import Instructions from './index';
 import { store, getExamAttemptsData, startTimedExam } from '../data';
-import { pollExamAttempt } from '../data/api';
+import { pollExamAttempt, softwareDownloadAttempt } from '../data/api';
 import { continueExam, submitExam } from '../data/thunks';
 import Emitter from '../data/emitter';
 import { TIMER_REACHED_NULL } from '../timer/events';
@@ -807,6 +807,7 @@ describe('SequenceExamWrapper', () => {
           attempt: Factory.build('attempt', {
             attempt_id: 4321,
             attempt_status: ExamStatus.CREATED,
+            use_legacy_attempt_api: false,
           }),
         }),
         getExamAttemptsData,
@@ -823,6 +824,7 @@ describe('SequenceExamWrapper', () => {
     );
     fireEvent.click(screen.getByText('Start System Check'));
     await waitFor(() => { expect(windowSpy).toHaveBeenCalledWith('http://localhost:18740/lti/start_proctoring/4321', '_blank'); });
+    expect(softwareDownloadAttempt).toHaveBeenCalledWith(4321, false);
 
     // also validate start button works
     pollExamAttempt.mockReturnValue(Promise.resolve({ status: ExamStatus.READY_TO_START }));

--- a/src/instructions/proctored_exam/download-instructions/index.jsx
+++ b/src/instructions/proctored_exam/download-instructions/index.jsx
@@ -55,7 +55,10 @@ const DownloadSoftwareProctoredExamInstructions = ({ intl, skipProctoredExam }) 
         if (data.status === ExamStatus.READY_TO_START) {
           setSystemCheckStatus('success');
         } else {
-          softwareDownloadAttempt(attemptId);
+          // TODO: This call circumvents the thunk for startProctoringSoftwareDownload
+          // which is a bit odd and would handle useLegacyAttempt for us.
+          // There's an opportunity to refactor and clean this up a bit.
+          softwareDownloadAttempt(attemptId, useLegacyAttemptApi);
           window.open(launchSoftwareUrl, '_blank');
         }
       });


### PR DESCRIPTION
Quick fix to unblock testing in stage. The update call for 'click_download_software' is always hitting edx-exams right now. I didn't replace this with the thunk which is what we probably should be doing long term. The way the thunk is written we'd end up making double calls to our latest attempt endpoint so it requires a bit more  refactoring to get there.