### PR TITLE
feat: notify proctorio app of exam start

### DIFF
--- a/src/data/messages/proctorio.js
+++ b/src/data/messages/proctorio.js
@@ -1,0 +1,15 @@
+/**
+ * Custom integration with Proctorio browser extension
+ *
+ * Note: this is a temporary solution, we would like to avoid
+ * vendor-specific integrations long term. As of now these events
+ * will trigger on ANY lti integration, not just Proctorio.
+ */
+function notifyStartExam() {
+  window.top.postMessage(
+    ['exam_state_change', 'exam_take'],
+    '*', // this isn't emitting secure data so any origin is fine
+  );
+}
+
+export default notifyStartExam;

--- a/src/data/redux.test.jsx
+++ b/src/data/redux.test.jsx
@@ -811,6 +811,23 @@ describe('Data layer integration tests', () => {
         },
       );
     });
+
+    it('Should notify top window on LTI exam start', async () => {
+      const mockPostMessage = jest.fn();
+      windowSpy.mockImplementation(() => ({
+        top: {
+          postMessage: mockPostMessage,
+        },
+      }));
+
+      await initWithExamAttempt(createdExam, createdAttempt);
+      axiosMock.onPost(createUpdateAttemptURL).reply(200, { exam_attempt_id: startedAttempt.attempt_id });
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: startedExam });
+      axiosMock.onGet(latestAttemptURL).reply(200, startedAttempt);
+
+      await executeThunk(thunks.startProctoredExam(), store.dispatch, store.getState);
+      expect(mockPostMessage).toHaveBeenCalledWith(['exam_state_change', 'exam_take'], '*');
+    });
   });
 
   describe('Test skipProctoringExam', () => {

--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -31,6 +31,7 @@ import {
 import { ExamStatus } from '../constants';
 import { workerPromiseForEventNames, pingApplication } from './messages/handlers';
 import actionToMessageTypesMap from './messages/constants';
+import notifyStartExam from './messages/proctorio';
 
 function handleAPIError(error, dispatch) {
   const { message, detail } = error;
@@ -183,6 +184,7 @@ export function startProctoredExam() {
     }
     const { desktop_application_js_url: workerUrl } = attempt || {};
     const useWorker = window.Worker && workerUrl;
+    const examHasLtiProvider = !exam.useLegacyAttemptApi;
 
     if (useWorker) {
       const startExamTimeoutMilliseconds = EXAM_START_TIMEOUT_MILLISECONDS;
@@ -209,6 +211,9 @@ export function startProctoredExam() {
           );
         });
     } else {
+      if (examHasLtiProvider) {
+        notifyStartExam();
+      }
       await updateAttemptAfter(
         exam.course_id, exam.content_id, continueAttempt(attempt.attempt_id, attempt.use_legacy_attempt_api),
       )(dispatch);


### PR DESCRIPTION
Waiting to merge until I confirm some details with Proctorio.

Add interface where we can send JS messages to the Proctorio browser application. This isn't ideal because it's an extra requirement beyond the LTI specification for proctored exam launches. However, this should't impact our certification as the edx platform does not rely on this message in any way.