### PR TITLE
feat: add end_exam message for proctorio

### DIFF
--- a/src/data/messages/proctorio.js
+++ b/src/data/messages/proctorio.js
@@ -5,11 +5,16 @@
  * vendor-specific integrations long term. As of now these events
  * will trigger on ANY lti integration, not just Proctorio.
  */
-function notifyStartExam() {
+export function notifyStartExam() {
   window.top.postMessage(
     ['exam_state_change', 'exam_take'],
     '*', // this isn't emitting secure data so any origin is fine
   );
 }
 
-export default notifyStartExam;
+export function notifyEndExam() {
+  window.top.postMessage(
+    ['exam_state_change', 'exam_end'],
+    '*', // this isn't emitting secure data so any origin is fine
+  );
+}

--- a/src/data/redux.test.jsx
+++ b/src/data/redux.test.jsx
@@ -581,6 +581,21 @@ describe('Data layer integration tests', () => {
       await executeThunk(thunks.submitExam(), store.dispatch, store.getState);
       expect(axiosMock.history.put[0].url).toEqual(updateAttemptStatusLegacyUrl);
     });
+
+    it('Should notify top window on LTI exam end', async () => {
+      const mockPostMessage = jest.fn();
+      windowSpy.mockImplementation(() => ({
+        top: {
+          postMessage: mockPostMessage,
+        },
+      }));
+
+      await initWithExamAttempt();
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: submittedExam });
+      axiosMock.onPut(`${createUpdateAttemptURL}/${attempt.attempt_id}`).reply(200, { exam_attempt_id: submittedAttempt.attempt_id });
+      await executeThunk(thunks.submitExam(), store.dispatch, store.getState);
+      expect(mockPostMessage).toHaveBeenCalledWith(['exam_state_change', 'exam_end'], '*');
+    });
   });
 
   describe('Test expireExam', () => {

--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -31,7 +31,7 @@ import {
 import { ExamStatus } from '../constants';
 import { workerPromiseForEventNames, pingApplication } from './messages/handlers';
 import actionToMessageTypesMap from './messages/constants';
-import notifyStartExam from './messages/proctorio';
+import { notifyEndExam, notifyStartExam } from './messages/proctorio';
 
 function handleAPIError(error, dispatch) {
   const { message, detail } = error;
@@ -364,6 +364,7 @@ export function submitExam() {
     const { exam, activeAttempt } = getState().examState;
     const { desktop_application_js_url: workerUrl, external_id: attemptExternalId } = activeAttempt || {};
     const useWorker = window.Worker && activeAttempt && workerUrl;
+    const examHasLtiProvider = !exam.useLegacyAttemptApi;
 
     const handleBackendProviderSubmission = () => {
       // if a backend provider is being used during the exam
@@ -374,6 +375,9 @@ export function submitExam() {
             { message: 'Something has gone wrong submitting your exam. Please double-check that the application is running.' },
             dispatch,
           ));
+      }
+      if (examHasLtiProvider) {
+        notifyEndExam();
       }
     };
 


### PR DESCRIPTION
## [MST-1930](https://2u-internal.atlassian.net/browse/MST-1930)

To temporarily support exam submission for Proctorio, add a feature to end an exam via Proctorio's postMessage API