### PR TITLE
fix: LTI exam use submit thunk

### DIFF
--- a/src/instructions/proctored_exam/SubmitProctoredExamInstructions.jsx
+++ b/src/instructions/proctored_exam/SubmitProctoredExamInstructions.jsx
@@ -20,9 +20,8 @@ const SubmitProctoredExamInstructions = () => {
   const handleSubmitClick = () => {
     if (examHasLtiProvider) {
       window.open(submitLtiAttemptUrl, '_blank');
-    } else {
-      submitExam();
     }
+    submitExam();
   };
 
   return (


### PR DESCRIPTION
Fixes issue where the end exam JS function wasn't called. Easiest solution was to just run the submitExam thunk anyway for LTI exams. This gets us a working flow with Proctorio while they work out support for the LtiEndAssessment message. Once that exists we no longer need to call submit here.

Tested against the IMS tool, doesn't negatively impact that flow.