### PR TITLE
fix: pollAttempt call on download page

### DIFF
--- a/src/data/__snapshots__/redux.test.jsx.snap
+++ b/src/data/__snapshots__/redux.test.jsx.snap
@@ -197,7 +197,7 @@ Object {
   "in_timed_exam": true,
   "software_download_url": "",
   "taking_as_proctored": false,
-  "time_remaining_seconds": 1739.9,
+  "time_remaining_seconds": 1799.9,
   "total_time": "30 minutes",
 }
 `;

--- a/src/data/api.js
+++ b/src/data/api.js
@@ -1,14 +1,24 @@
 import { getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { logError } from '@edx/frontend-platform/logging';
 import { ExamAction } from '../constants';
 import { generateHumanizedTime } from '../helpers';
 
 const BASE_API_URL = '/api/edx_proctoring/v1/proctored_exam/attempt';
 
 async function fetchActiveAttempt() {
+  // fetch 'active' (timer is running) attempt if it exists
   const activeAttemptUrl = new URL(`${getConfig().EXAMS_BASE_URL}/api/v1/exams/attempt/latest`);
   const activeAttemptResponse = await getAuthenticatedHttpClient().get(activeAttemptUrl.href);
   return activeAttemptResponse.data;
+}
+
+async function fetchLatestExamAttempt(sequenceId) {
+  // fetch lastest attempt for a specific exam
+  const attemptUrl = new URL(`${getConfig().EXAMS_BASE_URL}/api/v1/exams/attempt/latest`);
+  attemptUrl.searchParams.append('content_id', sequenceId);
+  const response = await getAuthenticatedHttpClient().get(attemptUrl.href);
+  return response.data;
 }
 
 export async function fetchExamAttemptsData(courseId, sequenceId) {
@@ -56,22 +66,24 @@ export async function fetchLatestAttempt(courseId) {
   return data;
 }
 
-export async function pollExamAttempt(url) {
+export async function pollExamAttempt(pollUrl, sequenceId) {
   let data;
-  if (!getConfig().EXAMS_BASE_URL) {
+  if (pollUrl) {
     const edxProctoringURL = new URL(
-      `${getConfig().LMS_BASE_URL}${url}`,
+      `${getConfig().LMS_BASE_URL}${pollUrl}`,
     );
     const urlResponse = await getAuthenticatedHttpClient().get(edxProctoringURL.href);
     data = urlResponse.data;
-  } else {
-    data = await fetchActiveAttempt();
+  } else if (getConfig().EXAMS_BASE_URL) {
+    data = await fetchLatestExamAttempt(sequenceId);
 
     // Update dictionaries returned by edx-exams to have correct status key for legacy compatibility
     if (data.attempt_status) {
       data.status = data.attempt_status;
       delete data.attempt_status;
     }
+  } else {
+    logError('pollExamAttempt called but no pollUrl is set');
   }
   return data;
 }

--- a/src/data/api.js
+++ b/src/data/api.js
@@ -87,7 +87,7 @@ export async function pollExamAttempt(pollUrl, sequenceId) {
   } else {
     // sites configured with only edx-proctoring must have pollUrl set
     // sites configured with edx-exams expect sequenceId if pollUrl is not set
-    logError('pollExamAttempt recieved unexpected parameters pollUrl=${pollUrl} sequenceId=${sequenceId}');
+    logError(`pollExamAttempt recieved unexpected parameters pollUrl=${pollUrl} sequenceId=${sequenceId}`);
   }
   return data;
 }

--- a/src/instructions/proctored_exam/download-instructions/index.jsx
+++ b/src/instructions/proctored_exam/download-instructions/index.jsx
@@ -50,7 +50,7 @@ const DownloadSoftwareProctoredExamInstructions = ({ intl, skipProctoredExam }) 
     ? `${getConfig().EXAMS_BASE_URL}/lti/start_proctoring/${attemptId}` : downloadUrl;
 
   const handleDownloadClick = () => {
-    pollExamAttempt(`${pollUrl}?sourceid=instructions`)
+    pollExamAttempt(pollUrl, sequenceId)
       .then((data) => {
         if (data.status === ExamStatus.READY_TO_START) {
           setSystemCheckStatus('success');
@@ -66,7 +66,7 @@ const DownloadSoftwareProctoredExamInstructions = ({ intl, skipProctoredExam }) 
   };
 
   const handleStartExamClick = () => {
-    pollExamAttempt(`${pollUrl}?sourceid=instructions`)
+    pollExamAttempt(pollUrl, sequenceId)
       .then((data) => (
         data.status === ExamStatus.READY_TO_START
           ? getExamAttemptsData(courseId, sequenceId)


### PR DESCRIPTION
### [MST-1951](https://2u-internal.atlassian.net/browse/MST-1951)

pair PR with https://github.com/edx/frontend-app-exams-dashboard/pull/11

The network call made by the download interstitial is a bit of a special snowflake it bypasses the thunk and calls the api directly. Added support to the existing 'poll' function to support requesting a specific exam by sequence id in this case.