### PR TITLE
fix: timer polling url for LTI exams

### DIFF
--- a/src/timer/TimerProvider.jsx
+++ b/src/timer/TimerProvider.jsx
@@ -54,9 +54,8 @@ const TimerServiceProvider = ({
   ).join(':');
 
   const pollExam = () => {
-    const url = attempt.exam_started_poll_url;
-    const queryString = `?sourceid=in_exam&proctored=${attempt.taking_as_proctored}`;
-    pollHandler(url + queryString);
+    // poll url may be null if this is an LTI exam
+    pollHandler(attempt.exam_started_poll_url);
   };
 
   const processTimeLeft = (timer, secondsLeft) => {


### PR DESCRIPTION
This query string appears to just be some copy/paste from the old proctoring UI. It's not used for anything and causes the pollHandler to send failing requests if the attempt has no polling url. The cropped up after https://github.com/openedx/frontend-lib-special-exams/pull/113 was merged.

Tested manually. At the moment this component has no tests 😞 