### PR TITLE
refactor: updated lock file version check to use new workflow

### DIFF
--- a/.github/workflows/lockfileversion-check.yml
+++ b/.github/workflows/lockfileversion-check.yml
@@ -10,4 +10,4 @@ on:
 
 jobs:
   version-check:
-    uses: openedx/.github/.github/workflows/lockfileversion-check-v3.yml@master
+    uses: openedx/.github/.github/workflows/lockfile-check.yml@master


### PR DESCRIPTION
Renamed `lockfileversion-check-v3` to `lockfile-check` in lockfile version file.

# Ticket

[Prototype a way to review NPM lockfiles in PRs](https://github.com/edx/edx-arch-experiments/issues/355)