### PR TITLE
feat: use lti for exam end

### DIFF
--- a/src/data/messages/proctorio.js
+++ b/src/data/messages/proctorio.js
@@ -27,10 +27,3 @@ export function notifyStartExam() {
     '*', // this isn't emitting secure data so any origin is fine
   );
 }
-
-export function notifyEndExam() {
-  window.top.postMessage(
-    ['exam_state_change', 'exam_end'],
-    '*', // this isn't emitting secure data so any origin is fine
-  );
-}

--- a/src/data/redux.test.jsx
+++ b/src/data/redux.test.jsx
@@ -582,21 +582,6 @@ describe('Data layer integration tests', () => {
       await executeThunk(thunks.submitExam(), store.dispatch, store.getState);
       expect(axiosMock.history.put[0].url).toEqual(updateAttemptStatusLegacyUrl);
     });
-
-    it('Should notify top window on LTI exam end', async () => {
-      const mockPostMessage = jest.fn();
-      windowSpy.mockImplementation(() => ({
-        top: {
-          postMessage: mockPostMessage,
-        },
-      }));
-
-      await initWithExamAttempt();
-      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: submittedExam });
-      axiosMock.onPut(`${createUpdateAttemptURL}/${attempt.attempt_id}`).reply(200, { exam_attempt_id: submittedAttempt.attempt_id });
-      await executeThunk(thunks.submitExam(), store.dispatch, store.getState);
-      expect(mockPostMessage).toHaveBeenCalledWith(['exam_state_change', 'exam_end'], '*');
-    });
   });
 
   describe('Test expireExam', () => {

--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -31,7 +31,7 @@ import {
 import { ExamStatus, ExamType, IS_PROCTORED_STATUS } from '../constants';
 import { workerPromiseForEventNames, pingApplication } from './messages/handlers';
 import actionToMessageTypesMap from './messages/constants';
-import { checkAppStatus, notifyEndExam, notifyStartExam } from './messages/proctorio';
+import { checkAppStatus, notifyStartExam } from './messages/proctorio';
 
 function handleAPIError(error, dispatch) {
   const { message, detail } = error;
@@ -364,7 +364,6 @@ export function submitExam() {
     const { exam, activeAttempt } = getState().examState;
     const { desktop_application_js_url: workerUrl, external_id: attemptExternalId } = activeAttempt || {};
     const useWorker = window.Worker && activeAttempt && workerUrl;
-    const examHasLtiProvider = !exam.useLegacyAttemptApi;
 
     const handleBackendProviderSubmission = () => {
       // if a backend provider is being used during the exam
@@ -375,9 +374,6 @@ export function submitExam() {
             { message: 'Something has gone wrong submitting your exam. Please double-check that the application is running.' },
             dispatch,
           ));
-      }
-      if (examHasLtiProvider) {
-        notifyEndExam();
       }
     };
 

--- a/src/instructions/proctored_exam/ProctoredExamInstructions.test.jsx
+++ b/src/instructions/proctored_exam/ProctoredExamInstructions.test.jsx
@@ -197,8 +197,12 @@ describe('SequenceExamWrapper', () => {
   });
 
   it('Initiates an LTI launch in a new window when the user clicks the submit button', async () => {
-    const windowSpy = jest.spyOn(window, 'open');
-    windowSpy.mockImplementation(() => ({}));
+    const { location } = window;
+    delete window.location;
+    const mockAssign = jest.fn();
+    window.location = {
+      assign: mockAssign,
+    };
     const attempt = Factory.build('attempt', {
       attempt_status: ExamStatus.READY_TO_SUBMIT,
       use_legacy_attempt_api: false,
@@ -226,7 +230,10 @@ describe('SequenceExamWrapper', () => {
 
     expect(queryByTestId('proctored-exam-instructions-title')).toHaveTextContent('Are you sure you want to end your proctored exam?');
     fireEvent.click(queryByTestId('end-exam-button'));
-    await waitFor(() => { expect(windowSpy).toHaveBeenCalledWith('http://localhost:18740/lti/end_assessment/1', '_blank'); });
+    await waitFor(() => { expect(mockAssign).toHaveBeenCalledWith('http://localhost:18740/lti/end_assessment/1'); });
+
+    // restore window.location
+    window.location = location;
   });
 
   it('Instructions are shown when attempt status is verified', () => {

--- a/src/instructions/proctored_exam/SubmitProctoredExamInstructions.jsx
+++ b/src/instructions/proctored_exam/SubmitProctoredExamInstructions.jsx
@@ -19,7 +19,7 @@ const SubmitProctoredExamInstructions = () => {
 
   const handleSubmitClick = () => {
     if (examHasLtiProvider) {
-      window.open(submitLtiAttemptUrl, '_blank');
+      window.location.assign(submitLtiAttemptUrl);
     }
     submitExam();
   };


### PR DESCRIPTION
### [MST-2099](https://2u-internal.atlassian.net/browse/MST-2099)

- removes temporary window.postMessage for exam submission. The new proctoring app will use LTI
- update submission flow to use a single tab

This needs to get merged in conjunction with the new Proctorio extension so I'll hold merging until that goes out.