### PR TITLE
fix: exam state null check

### DIFF
--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -539,7 +539,7 @@ export function checkExamEntry() {
     const { exam } = getState().examState;
     // Check only applies to LTI exams
     if (
-      !exam.attempt
+      !exam?.attempt
       || exam.attempt.exam_type !== ExamType.PROCTORED
       || exam.attempt.use_legacy_attempt_api
     ) { return; }


### PR DESCRIPTION
Fixes a test failure in the learning MFE where the exam state was null. This is probably a good safety check to have anyway since this check runs on all subsections.