### PR TITLE
fix: check app domain

### DIFF
--- a/src/data/messages/proctorio.js
+++ b/src/data/messages/proctorio.js
@@ -8,7 +8,7 @@
 export async function checkAppStatus() {
   return new Promise((resolve, reject) => {
     const handleResponse = event => {
-      if (event.origin === 'https://getproctorio.com') {
+      if (event.origin === window.location.origin) {
         window.removeEventListener('message', handleResponse);
         if (event?.data?.active) {
           resolve();

--- a/src/data/redux.test.jsx
+++ b/src/data/redux.test.jsx
@@ -1090,6 +1090,9 @@ describe('Data layer integration tests', () => {
         top: {
           postMessage: mockPostMessage,
         },
+        location: {
+          origin: 'https://edx.example.com',
+        },
         addEventListener: mockAddEventListener,
         removeEventListener: jest.fn(),
       }));
@@ -1149,7 +1152,7 @@ describe('Data layer integration tests', () => {
       await new Promise(process.nextTick);
       const handleResponseCb = mockAddEventListener.mock.calls[0][1];
       axiosMock.onPut(`${createUpdateAttemptURL}/${proctoredAttempt.attempt_id}`).reply(200, { exam_attempt_id: proctoredAttempt.attempt_id });
-      handleResponseCb({ origin: 'https://getproctorio.com', data: { active: false } });
+      handleResponseCb({ origin: 'https://edx.example.com', data: { active: false } });
 
       await new Promise(process.nextTick);
       const request = axiosMock.history.put[0];
@@ -1168,7 +1171,7 @@ describe('Data layer integration tests', () => {
 
       await new Promise(process.nextTick);
       const handleResponseCb = mockAddEventListener.mock.calls[0][1];
-      handleResponseCb({ origin: 'https://getproctorio.com', data: { active: true } });
+      handleResponseCb({ origin: 'https://edx.example.com', data: { active: true } });
 
       await new Promise(process.nextTick);
       expect(axiosMock.history.put.length).toBe(0);


### PR DESCRIPTION
Fixes a bug in https://github.com/openedx/frontend-lib-special-exams/pull/116

The domain for this message should actually match the current page. This differs from the Proctorio docs a bit since they are customizing the domain on the extension to match the edX learning app.