### PR TITLE
fix: double submit race condition

### DIFF
--- a/src/instructions/proctored_exam/SubmitProctoredExamInstructions.jsx
+++ b/src/instructions/proctored_exam/SubmitProctoredExamInstructions.jsx
@@ -20,8 +20,9 @@ const SubmitProctoredExamInstructions = () => {
   const handleSubmitClick = () => {
     if (examHasLtiProvider) {
       window.location.assign(submitLtiAttemptUrl);
+    } else {
+      submitExam();
     }
-    submitExam();
   };
 
   return (


### PR DESCRIPTION
Incorrect assumption that location.assign is a blocking call. This appears to cause submit() to possibly execute alongside the LTI redirect which would also submit the exam. There's still an issue with fully resolving the redirect to be solved but this issue is making it harder to debug.