### PR TITLE
chore: bump frontend-platform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@edx/frontend-build": "13.0.1",
-        "@edx/frontend-platform": "5.0.0",
+        "@edx/frontend-platform": "5.5.4",
         "@edx/paragon": "20.44.0",
         "@edx/reactifex": "^2.1.1",
         "@reduxjs/toolkit": "^1.5.1",
@@ -2390,9 +2390,9 @@
       }
     },
     "node_modules/@edx/frontend-platform": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-5.0.0.tgz",
-      "integrity": "sha512-DD9/B4rnC3BKPiWlbEFF1JIYFbWC6vUBKTyN8sf4khi4DNhhWhsobk+iNeCWNzF9UgCPRbniIqesdV1F9NXNZw==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-5.5.4.tgz",
+      "integrity": "sha512-Yum+oST7XfDwDnDhBnzeR/mjp6O+G0g+5AZtIJ1BdTKQH1z9FObfim/pfoiI9STiYlguVpeWMkzWuca/QMLO/Q==",
       "dev": true,
       "dependencies": {
         "@cospired/i18n-iso-languages": "4.1.0",
@@ -2421,7 +2421,7 @@
       },
       "peerDependencies": {
         "@edx/frontend-build": ">= 8.1.0 || ^12.9.0-alpha.1",
-        "@edx/paragon": ">= 10.0.0 < 21.0.0",
+        "@edx/paragon": ">= 10.0.0 < 22.0.0",
         "prop-types": "^15.7.2",
         "react": "^16.9.0 || ^17.0.0",
         "react-dom": "^16.9.0 || ^17.0.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@edx/frontend-build": "13.0.1",
-    "@edx/frontend-platform": "5.0.0",
+    "@edx/frontend-platform": "5.5.4",
     "@edx/paragon": "20.44.0",
     "@edx/reactifex": "^2.1.1",
     "@reduxjs/toolkit": "^1.5.1",


### PR DESCRIPTION
# Description
This PR resolves the `PUBLIC_PATH` configuration issue by upgrading frontend-platform from `v5.0.0` to `v5.5.4`.