### PR TITLE
feat: update checkApp origin requirement

### DIFF
--- a/src/data/messages/proctorio.js
+++ b/src/data/messages/proctorio.js
@@ -5,10 +5,12 @@
  * vendor-specific integrations long term. As of now these events
  * will trigger on ANY lti integration, not just Proctorio.
  */
+import { getConfig } from '@edx/frontend-platform';
+
 export async function checkAppStatus() {
   return new Promise((resolve, reject) => {
     const handleResponse = event => {
-      if (event.origin === window.location.origin) {
+      if (event.origin === getConfig().EXAMS_BASE_URL) {
         window.removeEventListener('message', handleResponse);
         if (event?.data?.active) {
           resolve();

--- a/src/data/redux.test.jsx
+++ b/src/data/redux.test.jsx
@@ -1152,7 +1152,7 @@ describe('Data layer integration tests', () => {
       await new Promise(process.nextTick);
       const handleResponseCb = mockAddEventListener.mock.calls[0][1];
       axiosMock.onPut(`${createUpdateAttemptURL}/${proctoredAttempt.attempt_id}`).reply(200, { exam_attempt_id: proctoredAttempt.attempt_id });
-      handleResponseCb({ origin: 'https://edx.example.com', data: { active: false } });
+      handleResponseCb({ origin: 'http://localhost:18740', data: { active: false } });
 
       await new Promise(process.nextTick);
       const request = axiosMock.history.put[0];
@@ -1171,7 +1171,7 @@ describe('Data layer integration tests', () => {
 
       await new Promise(process.nextTick);
       const handleResponseCb = mockAddEventListener.mock.calls[0][1];
-      handleResponseCb({ origin: 'https://edx.example.com', data: { active: true } });
+      handleResponseCb({ origin: 'http://localhost:18740', data: { active: true } });
 
       await new Promise(process.nextTick);
       expect(axiosMock.history.put.length).toBe(0);


### PR DESCRIPTION
The proctorio extension running the exam will use a url on the exams service instead of the MFE url.

More details in https://github.com/edx/edx-exams/pull/227