### PR TITLE
feat: reduce unnecessary api calls

### DIFF
--- a/src/exam/ExamWrapper.jsx
+++ b/src/exam/ExamWrapper.jsx
@@ -27,7 +27,10 @@ const ExamWrapper = ({ children, ...props }) => {
   const isGated = sequence && sequence.gatedContent !== undefined && sequence.gatedContent.gated;
 
   useEffect(() => {
-    loadInitialData();
+    // fetch exam data on exam sequences or if no exam data has been fetched yet
+    if (sequence.isTimeLimited || state.isLoading) {
+      loadInitialData();
+    }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/exam/ExamWrapper.test.jsx
+++ b/src/exam/ExamWrapper.test.jsx
@@ -2,16 +2,28 @@ import '@testing-library/jest-dom';
 import { Factory } from 'rosie';
 import React from 'react';
 import SequenceExamWrapper from './ExamWrapper';
-import { store, getExamAttemptsData, startTimedExam } from '../data';
+import { store, startTimedExam } from '../data';
+import { getExamAttemptsData } from '../data/thunks';
 import { render, waitFor } from '../setupTest';
 import ExamStateProvider from '../core/ExamStateProvider';
 import { ExamStatus, ExamType } from '../constants';
 
 jest.mock('../data', () => ({
   store: {},
-  getExamAttemptsData: jest.fn(),
   startTimedExam: jest.fn(),
 }));
+
+// because of the way ExamStateProvider and other locations inconsistantly import from
+// thunks directly instead of using the data module we need to mock the underlying
+// thunk file. It would be nice to clean this up in the future.
+jest.mock('../data/thunks', () => {
+  const originalModule = jest.requireActual('../data/thunks');
+  return {
+    ...originalModule,
+    getExamAttemptsData: jest.fn(),
+  };
+});
+
 getExamAttemptsData.mockReturnValue(jest.fn());
 startTimedExam.mockReturnValue(jest.fn());
 store.subscribe = jest.fn();
@@ -24,10 +36,15 @@ describe('SequenceExamWrapper', () => {
   };
   const courseId = 'course-v1:test+test+test';
 
-  it('is successfully rendered and shows instructions if the user is not staff', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
     store.getState = () => ({
       examState: Factory.build('examState'),
+      isLoading: false,
     });
+  });
+
+  it('is successfully rendered and shows instructions if the user is not staff', () => {
     const { queryByTestId } = render(
       <ExamStateProvider>
         <SequenceExamWrapper sequence={sequence} courseId={courseId}>
@@ -114,13 +131,7 @@ describe('SequenceExamWrapper', () => {
     expect(queryByTestId('exam-api-error-component')).not.toBeInTheDocument();
   });
 
-  it('does not fetch exam data if already loaded and the sequence is not an exam', () => {
-    store.getState = () => ({
-      examState: Factory.build('examState', {
-        isLoading: false,
-      }),
-    });
-
+  it('does not fetch exam data if already loaded and the sequence is not an exam', async () => {
     render(
       <ExamStateProvider>
         <SequenceExamWrapper sequence={{ ...sequence, isTimeLimited: false }} courseId={courseId}>
@@ -129,7 +140,8 @@ describe('SequenceExamWrapper', () => {
       </ExamStateProvider>,
       { store },
     );
-    expect(getExamAttemptsData).not.toHaveBeenCalled();
+    // assert the exam data is not fetched
+    await expect(waitFor(() => expect(getExamAttemptsData).toHaveBeenCalled())).rejects.toThrow();
   });
 
   it('does fetch exam data for non exam sequences if not already loaded', async () => {
@@ -137,7 +149,6 @@ describe('SequenceExamWrapper', () => {
     store.getState = () => ({
       examState: Factory.build('examState', {
         isLoading: true,
-        getExamAttemptsData,
       }),
     });
 
@@ -149,11 +160,7 @@ describe('SequenceExamWrapper', () => {
       </ExamStateProvider>,
       { store },
     );
-
-    // can't figure out this test. For whatever reason the mock getExamAttemptsData
-    // is overriden by the actual value whenever this component is rendered.
-    // This pattern works in other tests.
-    // await waitFor(() => expect(getExamAttemptsData).toHaveBeenCalled());
+    await waitFor(() => expect(getExamAttemptsData).toHaveBeenCalled());
   });
 
   it('does not take any actions if sequence item is not exam', () => {


### PR DESCRIPTION
Every sequence navigation renders a new ExamWrapper component causing us to hit the `/latest` endpoint every time. We really only need to do this in a few cases.

1. If the sequence is an exam itself
2. If we've first loaded the UI and there is an active exam in another sequence

If the store already has a latest exam there's no reason to keep checking it on every user navigation, the polling function will already take care of refreshing data. I expect this change to drastically reduce the number of API calls we're generating.