### PR TITLE
Refactor TimerServiceProvider to no longer use withExamStore higher-order-component.

### DIFF
--- a/src/core/OuterExamTimer.jsx
+++ b/src/core/OuterExamTimer.jsx
@@ -1,22 +1,24 @@
 import React, { useEffect, useContext } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { AppContext } from '@edx/frontend-platform/react';
 import ExamStateContext from '../context';
+import { getLatestAttemptData } from '../data';
 import { ExamTimerBlock } from '../timer';
 import ExamAPIError from '../exam/ExamAPIError';
 import ExamStateProvider from './ExamStateProvider';
 
 const ExamTimer = ({ courseId }) => {
-  const state = useContext(ExamStateContext);
+  const examState = useContext(ExamStateContext);
   const { authenticatedUser } = useContext(AppContext);
-  const {
-    activeAttempt, showTimer, stopExam, submitExam,
-    expireExam, pollAttempt, apiErrorMsg, pingAttempt,
-    getLatestAttemptData,
-  } = state;
+  const { showTimer } = examState;
+
+  const { apiErrorMsg } = useSelector(state => state.specialExams);
+
+  const dispatch = useDispatch();
 
   useEffect(() => {
-    getLatestAttemptData(courseId);
+    dispatch(getLatestAttemptData(courseId));
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [courseId]);
 
@@ -29,14 +31,7 @@ const ExamTimer = ({ courseId }) => {
   return (
     <div className="d-flex flex-column justify-content-center">
       {showTimer && (
-        <ExamTimerBlock
-          attempt={activeAttempt}
-          stopExamAttempt={stopExam}
-          submitExam={submitExam}
-          expireExamAttempt={expireExam}
-          pollExamAttempt={pollAttempt}
-          pingAttempt={pingAttempt}
-        />
+        <ExamTimerBlock />
       )}
       {apiErrorMsg && <ExamAPIError />}
     </div>

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -18,5 +18,9 @@ export {
   examRequiresAccessToken,
 } from './thunks';
 
+export {
+  expireExamAttempt,
+} from './slice';
+
 export { default as store } from './store';
 export { default as Emitter } from './emitter';

--- a/src/exam/Exam.jsx
+++ b/src/exam/Exam.jsx
@@ -25,9 +25,7 @@ const Exam = ({
 }) => {
   const state = useContext(ExamStateContext);
   const {
-    isLoading, activeAttempt, showTimer, stopExam, exam,
-    expireExam, pollAttempt, apiErrorMsg, pingAttempt,
-    getProctoringSettings, submitExam,
+    isLoading, showTimer, exam, apiErrorMsg, getProctoringSettings,
   } = state;
 
   const {
@@ -104,14 +102,7 @@ const Exam = ({
         </Alert>
       )}
       {showTimer && (
-        <ExamTimerBlock
-          attempt={activeAttempt}
-          stopExamAttempt={stopExam}
-          submitExam={submitExam}
-          expireExamAttempt={expireExam}
-          pollExamAttempt={pollAttempt}
-          pingAttempt={pingAttempt}
-        />
+        <ExamTimerBlock />
       )}
       { // show the error message only if you are in the exam sequence
         isTimeLimited && apiErrorMsg && <ExamAPIError />

--- a/src/timer/ExamTimerBlock.jsx
+++ b/src/timer/ExamTimerBlock.jsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from 'react';
-import PropTypes from 'prop-types';
+import { useDispatch, useSelector } from 'react-redux';
 import { FormattedMessage, injectIntl } from '@edx/frontend-platform/i18n';
 import { Button, Alert, useToggle } from '@edx/paragon';
 import CountDownTimer from './CountDownTimer';
 import { ExamStatus, IS_STARTED_STATUS } from '../constants';
 import TimerProvider from './TimerProvider';
-import { Emitter } from '../data';
+import {
+  Emitter, expireExamAttempt, stopExam, submitExam,
+} from '../data';
 import {
   TIMER_IS_CRITICALLY_LOW,
   TIMER_IS_LOW,
@@ -16,13 +18,12 @@ import {
 /**
  * Exam timer block component.
  */
-const ExamTimerBlock = injectIntl(({
-  attempt, stopExamAttempt, expireExamAttempt, pollExamAttempt,
-  intl, pingAttempt, submitExam,
-}) => {
+const ExamTimerBlock = injectIntl(({ intl }) => {
+  const { activeAttempt: attempt } = useSelector(state => state.specialExams);
   const [isShowMore, showMore, showLess] = useToggle(false);
   const [alertVariant, setAlertVariant] = useState('info');
   const [timeReachedNull, setTimeReachedNull] = useState(false);
+  const dispatch = useDispatch();
 
   if (!attempt || !IS_STARTED_STATUS(attempt.attempt_status)) {
     return null;
@@ -36,29 +37,29 @@ const ExamTimerBlock = injectIntl(({
     // if timer reached 00:00 submit exam right away
     // instead of trying to move user to ready_to_submit page
     if (timeReachedNull) {
-      submitExam();
+      dispatch(submitExam());
     } else {
-      stopExamAttempt();
+      dispatch(stopExam());
     }
   };
 
   useEffect(() => {
     Emitter.once(TIMER_IS_LOW, onLowTime);
     Emitter.once(TIMER_IS_CRITICALLY_LOW, onCriticalLowTime);
-    Emitter.once(TIMER_LIMIT_REACHED, expireExamAttempt);
+    Emitter.once(TIMER_LIMIT_REACHED, () => dispatch(expireExamAttempt));
     Emitter.once(TIMER_REACHED_NULL, onTimeReachedNull);
 
     return () => {
       Emitter.off(TIMER_IS_LOW, onLowTime);
       Emitter.off(TIMER_IS_CRITICALLY_LOW, onCriticalLowTime);
-      Emitter.off(TIMER_LIMIT_REACHED, expireExamAttempt);
+      Emitter.off(TIMER_LIMIT_REACHED, () => dispatch(expireExamAttempt));
       Emitter.off(TIMER_REACHED_NULL, onTimeReachedNull);
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
-    <TimerProvider attempt={attempt} pollHandler={pollExamAttempt} pingHandler={pingAttempt}>
+    <TimerProvider>
       <Alert variant={alertVariant}>
         <div
           className="d-flex justify-content-between flex-column flex-lg-row align-items-start"
@@ -132,15 +133,6 @@ const ExamTimerBlock = injectIntl(({
   );
 });
 
-ExamTimerBlock.propTypes = {
-  attempt: PropTypes.shape({
-    exam_url_path: PropTypes.string.isRequired,
-    exam_display_name: PropTypes.string.isRequired,
-    time_remaining_seconds: PropTypes.number.isRequired,
-  }),
-  stopExamAttempt: PropTypes.func.isRequired,
-  expireExamAttempt: PropTypes.func.isRequired,
-  submitExam: PropTypes.func.isRequired,
-};
+ExamTimerBlock.propTypes = {};
 
 export default ExamTimerBlock;


### PR DESCRIPTION
### Description:

**Jira**: [COSMO-174](https://2u-internal.atlassian.net/browse/COSMO-174)

* refactor: replace use of withExamStore higher-order component in TimerServiceProvider
  * This commit replaces the use of the withExamStore higher-order component with the useDispatch and useSelector hooks in TimerServiceProvider.
  * This commit also refactors components that use the TimerServiceProvider so that they no longer need to pass state and action creators via props. The TimerServiceProvider now gets whatever state it needs directly from the Redux store with a useSelector hook and imports and dispatches thunks directly by importing them from the data directory.
  * The original pattern was to use the withExamStore higher-order component to provide context to the TimerServiceProvider and its children. This context contained provided the Redux store state and action creators as props by using the connect API. This posed a problem for our need to merge the frontend-app-learning and frontend-lib-special-exams stores, because the special exams store is initialized in this repository and used by the higher-order component. In order to eventually be able to remove the creation of the store in this repository, we have to remove references to the store by interfacing with the Redux more directly by using the useDispatch and useSelector hooks.