### PR TITLE
fix: pass sequenceId to api call

### DIFF
--- a/src/data/__snapshots__/redux.test.jsx.snap
+++ b/src/data/__snapshots__/redux.test.jsx.snap
@@ -203,6 +203,7 @@ Object {
   "software_download_url": "",
   "taking_as_proctored": false,
   "time_remaining_seconds": 1739.9,
+  "timer_ends": "2024-03-11T17:31:55.297Z",
   "total_time": "30 minutes",
 }
 `;

--- a/src/data/__snapshots__/redux.test.jsx.snap
+++ b/src/data/__snapshots__/redux.test.jsx.snap
@@ -188,7 +188,7 @@ Object {
 }
 `;
 
-exports[`Data layer integration tests Test pollAttempt Should poll and update active attempt 1`] = `
+exports[`Data layer integration tests Test pollAttempt Should poll and update active attempt with new proctoring backend 1`] = `
 Object {
   "attempt_code": "",
   "attempt_id": 1,
@@ -202,46 +202,7 @@ Object {
   "in_timed_exam": true,
   "software_download_url": "",
   "taking_as_proctored": false,
-  "time_remaining_seconds": 1799.9,
-  "timer_ends": Any<String>,
-  "total_time": "30 minutes",
-}
-`;
-
-exports[`Data layer integration tests Test pollAttempt with edx-proctoring as a backend (no EXAMS_BASE_URL) Should poll and update active attempt 1`] = `
-Object {
-  "attempt_code": "",
-  "attempt_id": 1,
-  "attempt_status": "started",
-  "course_id": "course-v1:test+special+exam",
-  "desktop_application_js_url": "",
-  "exam_display_name": "a timed exam",
-  "exam_started_poll_url": "/api/edx_proctoring/v1/proctored_exam/attempt/1",
-  "exam_type": "timed",
-  "exam_url_path": "http://localhost:2000/course/course-v1:test+special+exam/block-v1:test+special+exam+type@sequential+block@abc123",
-  "in_timed_exam": true,
-  "software_download_url": "",
-  "taking_as_proctored": false,
-  "time_remaining_seconds": 1799.9,
-  "total_time": "30 minutes",
-}
-`;
-
-exports[`Data layer integration tests Test pollAttempt with edx-proctoring as a backend (no EXAMS_BASE_URL) Should poll and update active attempt 2`] = `
-Object {
-  "attempt_code": "",
-  "attempt_id": 1,
-  "attempt_status": "started",
-  "course_id": "course-v1:test+special+exam",
-  "desktop_application_js_url": "",
-  "exam_display_name": "a timed exam",
-  "exam_started_poll_url": "/api/edx_proctoring/v1/proctored_exam/attempt/1",
-  "exam_type": "timed",
-  "exam_url_path": "http://localhost:2000/course/course-v1:test+special+exam/block-v1:test+special+exam+type@sequential+block@abc123",
-  "in_timed_exam": true,
-  "software_download_url": "",
-  "taking_as_proctored": false,
-  "time_remaining_seconds": 1799.9,
+  "time_remaining_seconds": 1739.9,
   "total_time": "30 minutes",
 }
 `;

--- a/src/data/__snapshots__/redux.test.jsx.snap
+++ b/src/data/__snapshots__/redux.test.jsx.snap
@@ -203,7 +203,45 @@ Object {
   "software_download_url": "",
   "taking_as_proctored": false,
   "time_remaining_seconds": 1739.9,
-  "timer_ends": "2024-03-11T17:31:55.297Z",
+  "timer_ends": Any<String>,
+  "total_time": "30 minutes",
+}
+`;
+
+exports[`Data layer integration tests Test pollAttempt with edx-proctoring as a backend (no EXAMS_BASE_URL) Should poll and update active attempt with legacy proctoring backend 1`] = `
+Object {
+  "attempt_code": "",
+  "attempt_id": 1,
+  "attempt_status": "started",
+  "course_id": "course-v1:test+special+exam",
+  "desktop_application_js_url": "",
+  "exam_display_name": "a timed exam",
+  "exam_started_poll_url": "/api/edx_proctoring/v1/proctored_exam/attempt/1",
+  "exam_type": "timed",
+  "exam_url_path": "http://localhost:2000/course/course-v1:test+special+exam/block-v1:test+special+exam+type@sequential+block@abc123",
+  "in_timed_exam": true,
+  "software_download_url": "",
+  "taking_as_proctored": false,
+  "time_remaining_seconds": 1799.9,
+  "total_time": "30 minutes",
+}
+`;
+
+exports[`Data layer integration tests Test pollAttempt with edx-proctoring as a backend (no EXAMS_BASE_URL) Should poll and update active attempt with legacy proctoring backend 2`] = `
+Object {
+  "attempt_code": "",
+  "attempt_id": 1,
+  "attempt_status": "started",
+  "course_id": "course-v1:test+special+exam",
+  "desktop_application_js_url": "",
+  "exam_display_name": "a timed exam",
+  "exam_started_poll_url": "/api/edx_proctoring/v1/proctored_exam/attempt/1",
+  "exam_type": "timed",
+  "exam_url_path": "http://localhost:2000/course/course-v1:test+special+exam/block-v1:test+special+exam+type@sequential+block@abc123",
+  "in_timed_exam": true,
+  "software_download_url": "",
+  "taking_as_proctored": false,
+  "time_remaining_seconds": 1799.9,
   "total_time": "30 minutes",
 }
 `;

--- a/src/data/api.js
+++ b/src/data/api.js
@@ -19,7 +19,6 @@ async function fetchLatestExamAttempt(sequenceId) {
   // even if it is not 'active' (timer is not running)
   const attemptUrl = new URL(`${getConfig().EXAMS_BASE_URL}/api/v1/exams/attempt/latest`);
   attemptUrl.searchParams.append('content_id', sequenceId);
-  console.log("attemptUrl:", attemptUrl.href);
   const response = await getAuthenticatedHttpClient().get(attemptUrl.href);
   return response.data;
 }

--- a/src/data/api.js
+++ b/src/data/api.js
@@ -19,6 +19,7 @@ async function fetchLatestExamAttempt(sequenceId) {
   // even if it is not 'active' (timer is not running)
   const attemptUrl = new URL(`${getConfig().EXAMS_BASE_URL}/api/v1/exams/attempt/latest`);
   attemptUrl.searchParams.append('content_id', sequenceId);
+  console.log("attemptUrl:", attemptUrl.href);
   const response = await getAuthenticatedHttpClient().get(attemptUrl.href);
   return response.data;
 }

--- a/src/data/redux.test.jsx
+++ b/src/data/redux.test.jsx
@@ -950,22 +950,16 @@ describe('Data layer integration tests', () => {
       // Reset history so we can get url at index 0 later
       axiosMock.resetHistory();
 
-      const attemptToPollURL = latestAttemptURL + '?content_id=block-v1%3Atest%2Bspecial%2Bexam%2Btype%40sequential%2Bblock%40abc123';
+      const attemptToPollURL = `${latestAttemptURL}?content_id=block-v1%3Atest%2Bspecial%2Bexam%2Btype%40sequential%2Bblock%40abc123`;
       axiosMock.onGet(attemptToPollURL).reply(200, {
         time_remaining_seconds: 1739.9,
         accessibility_time_string: 'you have 29 minutes remaining',
         attempt_status: ExamStatus.STARTED,
       });
-      
-      // ADD TEST HERE
+
+      // Make sure the thunk eventually calls the right URL
       await executeThunk(thunks.pollAttempt(null, exam.content_id), store.dispatch, store.getState);
       const state = store.getState();
-
-
-
-      // the api request
-      console.log("attemptToPollURL:", attemptToPollURL);
-      console.log(axiosMock.history.get);
       expect(axiosMock.history.get[0].url).toEqual(attemptToPollURL);
       expect(state.specialExams.activeAttempt).toMatchSnapshot();
     });

--- a/src/data/redux.test.jsx
+++ b/src/data/redux.test.jsx
@@ -945,7 +945,7 @@ describe('Data layer integration tests', () => {
       });
     });
 
-    it.only('Should poll and update active attempt with new proctoring backend', async () => {
+    it('Should poll and update active attempt with new proctoring backend', async () => {
       await initWithExamAttempt(exam, attempt);
       // Reset history so we can get url at index 0 later
       axiosMock.resetHistory();
@@ -961,7 +961,11 @@ describe('Data layer integration tests', () => {
       await executeThunk(thunks.pollAttempt(null, exam.content_id), store.dispatch, store.getState);
       const state = store.getState();
       expect(axiosMock.history.get[0].url).toEqual(attemptToPollURL);
-      expect(state.specialExams.activeAttempt).toMatchSnapshot();
+      expect(state.specialExams.activeAttempt).toMatchSnapshot({
+        // Allow for the timer_ends value to be any string, as it varies by milliseconds depending
+        // on how fast this test runs just about every time.
+        timer_ends: expect.any(String),
+      });
     });
 
     describe('pollAttempt api called directly', () => {

--- a/src/data/redux.test.jsx
+++ b/src/data/redux.test.jsx
@@ -925,7 +925,7 @@ describe('Data layer integration tests', () => {
         mergeConfig({ EXAMS_BASE_URL: null });
       });
 
-      it('Should poll and update active attempt', async () => {
+      it('Should poll and update active attempt with legacy proctoring backend', async () => {
         axiosMock.onGet(fetchExamAttemptsDataLegacyUrl).replyOnce(200, { exam, active_attempt: attempt });
         axiosMock.onGet(pollExamAttemptUrl).reply(200, {
           time_remaining_seconds: 1739.9,
@@ -945,22 +945,33 @@ describe('Data layer integration tests', () => {
       });
     });
 
-    it('Should poll and update active attempt', async () => {
+    it.only('Should poll and update active attempt with new proctoring backend', async () => {
       await initWithExamAttempt(exam, attempt);
+      // Reset history so we can get url at index 0 later
+      axiosMock.resetHistory();
 
-      axiosMock.onGet(latestAttemptURL).reply(200, {
+      const attemptToPollURL = latestAttemptURL + '?content_id=block-v1%3Atest%2Bspecial%2Bexam%2Btype%40sequential%2Bblock%40abc123';
+      axiosMock.onGet(attemptToPollURL).reply(200, {
         time_remaining_seconds: 1739.9,
         accessibility_time_string: 'you have 29 minutes remaining',
         attempt_status: ExamStatus.STARTED,
       });
-
-      await executeThunk(thunks.pollAttempt(attempt.exam_started_poll_url), store.dispatch, store.getState);
+      
+      // ADD TEST HERE
+      await executeThunk(thunks.pollAttempt(null, exam.content_id), store.dispatch, store.getState);
       const state = store.getState();
-      expectSpecialExamAttemptToMatchSnapshot(state.specialExams.activeAttempt);
+
+
+
+      // the api request
+      console.log("attemptToPollURL:", attemptToPollURL);
+      console.log(axiosMock.history.get);
+      expect(axiosMock.history.get[0].url).toEqual(attemptToPollURL);
+      expect(state.specialExams.activeAttempt).toMatchSnapshot();
     });
 
     describe('pollAttempt api called directly', () => {
-      // in the download view we call this function directly withough invoking the wrapping thunk
+      // in the download view we call this function directly without invoking the wrapping thunk
       it('should call pollUrl if one is provided', async () => {
         const pollExamAttemptUrl = `${getConfig().LMS_BASE_URL}${attempt.exam_started_poll_url}`;
         axiosMock.onGet(pollExamAttemptUrl).reply(200, {

--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -271,6 +271,8 @@ export function pollAttempt(url) {
     }
 
     try {
+      // TODO: make sure sequenceId pulled here is correct both in-exam-sequence and in outline
+      // test w/ timed exam
       const { exam } = getState().specialExams;
       const data = await pollExamAttempt(url, exam.content_id);
       if (!data) {

--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -271,7 +271,8 @@ export function pollAttempt(url) {
     }
 
     try {
-      const data = await pollExamAttempt(url);
+      const { exam } = getState().specialExams;
+      const data = await pollExamAttempt(url, exam.content_id);
       if (!data) {
         throw new Error('Poll Exam failed to fetch.');
       }


### PR DESCRIPTION
Fix for https://2u-internal.atlassian.net/browse/COSMO-125

We seemed to forget to pass the sequenceId to the backend API call in thunks.js. I just added that back in, hopefully this should work on stage now.