### PR TITLE
fix: workaround for pollAttempt fail in courseview

### DIFF
--- a/src/core/OuterExamTimer.jsx
+++ b/src/core/OuterExamTimer.jsx
@@ -8,10 +8,9 @@ import { getLatestAttemptData } from '../data';
 import { IS_STARTED_STATUS } from '../constants';
 
 const ExamTimer = ({ courseId }) => {
-  const { activeAttempt } = useSelector(state => state.specialExams);
+  const { activeAttempt, apiErrorMsg } = useSelector(state => state.specialExams);
   const { authenticatedUser } = useContext(AppContext);
   const showTimer = !!(activeAttempt && IS_STARTED_STATUS(activeAttempt.attempt_status));
-  const { apiErrorMsg } = useSelector(state => state.specialExams);
   const dispatch = useDispatch();
 
   useEffect(() => {

--- a/src/data/api.js
+++ b/src/data/api.js
@@ -18,6 +18,17 @@ async function fetchActiveAttempt(sequenceId = null) {
   return activeAttemptResponse.data;
 }
 
+async function fetchAttemptForExamSequnceId() {
+    // fetch 'active' (timer is running) attempt if it exists
+    const activeAttemptUrl = new URL(`${getConfig().EXAMS_BASE_URL}/api/v1/exams/attempt/latest`);
+    const activeAttemptResponse = await getAuthenticatedHttpClient().get(activeAttemptUrl.href);
+    // the calls the same endpoint as fetchActiveAttempt but it behaves slightly different
+    // with an exam's section specified. The attempt for that requested exam is always returned
+    // even if it is not 'active' (timer is not running)
+    activeAttemptUrl.searchParams.append('content_id', sequenceId);
+    return activeAttemptResponse.data;
+}
+
 export async function fetchExamAttemptsData(courseId, sequenceId) {
   let data;
   if (!getConfig().EXAMS_BASE_URL) {

--- a/src/data/api.js
+++ b/src/data/api.js
@@ -1,26 +1,21 @@
 import { getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
-import { logError } from '@edx/frontend-platform/logging';
 import { ExamAction } from '../constants';
 import { generateHumanizedTime } from '../helpers';
 
 const BASE_API_URL = '/api/edx_proctoring/v1/proctored_exam/attempt';
 
-async function fetchActiveAttempt() {
+async function fetchActiveAttempt(sequenceId = null) {
   // fetch 'active' (timer is running) attempt if it exists
   const activeAttemptUrl = new URL(`${getConfig().EXAMS_BASE_URL}/api/v1/exams/attempt/latest`);
   const activeAttemptResponse = await getAuthenticatedHttpClient().get(activeAttemptUrl.href);
+  if (sequenceId) {
+    // the calls the same endpoint as fetchActiveAttempt but it behaves slightly different
+    // with an exam's section specified. The attempt for that requested exam is always returned
+    // even if it is not 'active' (timer is not running)
+    activeAttemptUrl.searchParams.append('content_id', sequenceId);
+  }
   return activeAttemptResponse.data;
-}
-
-async function fetchLatestExamAttempt(sequenceId) {
-  // the calls the same endpoint as fetchActiveAttempt but it behaves slightly different
-  // with an exam's section specified. The attempt for that requested exam is always returned
-  // even if it is not 'active' (timer is not running)
-  const attemptUrl = new URL(`${getConfig().EXAMS_BASE_URL}/api/v1/exams/attempt/latest`);
-  attemptUrl.searchParams.append('content_id', sequenceId);
-  const response = await getAuthenticatedHttpClient().get(attemptUrl.href);
-  return response.data;
 }
 
 export async function fetchExamAttemptsData(courseId, sequenceId) {
@@ -70,25 +65,27 @@ export async function fetchLatestAttempt(courseId) {
 
 export async function pollExamAttempt(pollUrl, sequenceId) {
   let data;
+
+  // sites configured with only edx-proctoring must have pollUrl set
   if (pollUrl) {
     const edxProctoringURL = new URL(
       `${getConfig().LMS_BASE_URL}${pollUrl}`,
     );
     const urlResponse = await getAuthenticatedHttpClient().get(edxProctoringURL.href);
     data = urlResponse.data;
-  } else if (sequenceId && getConfig().EXAMS_BASE_URL) {
-    data = await fetchLatestExamAttempt(sequenceId);
 
+  // sites configured with edx-exams expect sequenceId if pollUrl is not set
+  // and the learner is viewing the exam sequence
+  // (the exam sequence is not consumed outside the exam sequence, e.g. in the course view)
+  } else {
+    data = await fetchActiveAttempt(sequenceId);
     // Update dictionaries returned by edx-exams to have correct status key for legacy compatibility
     if (data.attempt_status) {
       data.status = data.attempt_status;
       delete data.attempt_status;
     }
-  } else {
-    // sites configured with only edx-proctoring must have pollUrl set
-    // sites configured with edx-exams expect sequenceId if pollUrl is not set
-    logError(`pollExamAttempt recieved unexpected parameters pollUrl=${pollUrl} sequenceId=${sequenceId}`);
   }
+
   return data;
 }
 

--- a/src/data/redux.test.jsx
+++ b/src/data/redux.test.jsx
@@ -950,6 +950,7 @@ describe('Data layer integration tests', () => {
       // Reset history so we can get url at index 0 later
       axiosMock.resetHistory();
 
+      // FIXME: Have sequenceId initialized
       const attemptToPollURL = `${latestAttemptURL}?content_id=block-v1%3Atest%2Bspecial%2Bexam%2Btype%40sequential%2Bblock%40abc123`;
       axiosMock.onGet(attemptToPollURL).reply(200, {
         time_remaining_seconds: 1739.9,
@@ -990,16 +991,21 @@ describe('Data layer integration tests', () => {
         await api.pollExamAttempt(null, sequenceId);
         expect(axiosMock.history.get[0].url).toEqual(expectedUrl);
       });
-      test('pollUrl is required if edx-exams in not enabled, an error should be logged', async () => {
-        mergeConfig({ EXAMS_BASE_URL: null });
-        api.pollExamAttempt(null, null);
-        expect(loggingService.logError).toHaveBeenCalled();
+      test('should call the latest attempt w/o a sequence if if neither a pollUrl or sequence id is provided', async () => {
+        const expectedUrl = `${getConfig().EXAMS_BASE_URL}/api/v1/exams/attempt/latest`;
+        axiosMock.onGet(expectedUrl).reply(200, {
+          time_remaining_seconds: 1739.9,
+          status: ExamStatus.STARTED,
+        });
+        await api.pollExamAttempt(null);
+        expect(axiosMock.history.get[0].url).toEqual(expectedUrl);
       });
     });
   });
 
   describe('Test pingAttempt', () => {
     it('Should send attempt to error state on ping failure', async () => {
+      // FIXME:
       const startedWorkerAttempt = Factory.build('attempt', { attempt_status: ExamStatus.STARTED, desktop_application_js_url: 'http://proctortest.com' });
       const startedWorkerExam = Factory.build('exam', { attempt: startedWorkerAttempt });
       await initWithExamAttempt(startedWorkerExam, startedWorkerAttempt);
@@ -1028,6 +1034,7 @@ describe('Data layer integration tests', () => {
       });
 
       it('Should get, and save latest attempt', async () => {
+        // FIXME:
         const attemptDataUrl = `${getConfig().LMS_BASE_URL}${BASE_API_URL}/course_id/${courseId}?is_learning_mfe=true`;
         axiosMock.onGet(attemptDataUrl)
           .reply(200, {

--- a/src/data/redux.test.jsx
+++ b/src/data/redux.test.jsx
@@ -950,7 +950,6 @@ describe('Data layer integration tests', () => {
       // Reset history so we can get url at index 0 later
       axiosMock.resetHistory();
 
-      // FIXME: Have sequenceId initialized
       const attemptToPollURL = `${latestAttemptURL}?content_id=block-v1%3Atest%2Bspecial%2Bexam%2Btype%40sequential%2Bblock%40abc123`;
       axiosMock.onGet(attemptToPollURL).reply(200, {
         time_remaining_seconds: 1739.9,
@@ -1005,7 +1004,6 @@ describe('Data layer integration tests', () => {
 
   describe('Test pingAttempt', () => {
     it('Should send attempt to error state on ping failure', async () => {
-      // FIXME:
       const startedWorkerAttempt = Factory.build('attempt', { attempt_status: ExamStatus.STARTED, desktop_application_js_url: 'http://proctortest.com' });
       const startedWorkerExam = Factory.build('exam', { attempt: startedWorkerAttempt });
       await initWithExamAttempt(startedWorkerExam, startedWorkerAttempt);
@@ -1034,7 +1032,6 @@ describe('Data layer integration tests', () => {
       });
 
       it('Should get, and save latest attempt', async () => {
-        // FIXME:
         const attemptDataUrl = `${getConfig().LMS_BASE_URL}${BASE_API_URL}/course_id/${courseId}?is_learning_mfe=true`;
         axiosMock.onGet(attemptDataUrl)
           .reply(200, {

--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -273,6 +273,23 @@ export function pollAttempt(url) {
     try {
       // Why is this undefined in the course view? Let's see how it's called there...
       const { exam } = getState().specialExams;
+
+      // The content_id might accidentally come from another open sequence that is ALSO an exam
+      // but not the current exam
+      // How do we ensure the content_id is coming from the active_attempt?
+
+      // Need sequence id when there are multiple exams in a course so we don't get the attempt for another exam.
+      // Maybe we don't need sequence ID if we have an active attempts
+
+      // We just need to make sure we have the right content_id. Maybe we can get it from the
+      // attempt itself or from some other place???
+
+      // As a nuke option is don't call this outside sequence, wait until you get back to it???
+      // don't make this a situation that this is never called
+
+      // 1. Try and see what's in the attempt obj, see what can match the active attempt/current sequence id
+      // 2. Test edge cases in that doc
+      console.log({currentAttempt});
       const data = await pollExamAttempt(url, exam.content_id);
       if (!data) {
         throw new Error('Poll Exam failed to fetch.');

--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -271,25 +271,7 @@ export function pollAttempt(url) {
     }
 
     try {
-      // Why is this undefined in the course view? Let's see how it's called there...
       const { exam } = getState().specialExams;
-
-      // The content_id might accidentally come from another open sequence that is ALSO an exam
-      // but not the current exam
-      // How do we ensure the content_id is coming from the active_attempt?
-
-      // Need sequence id when there are multiple exams in a course so we don't get the attempt for another exam.
-      // Maybe we don't need sequence ID if we have an active attempts
-
-      // We just need to make sure we have the right content_id. Maybe we can get it from the
-      // attempt itself or from some other place???
-
-      // As a nuke option is don't call this outside sequence, wait until you get back to it???
-      // don't make this a situation that this is never called
-
-      // 1. Try and see what's in the attempt obj, see what can match the active attempt/current sequence id
-      // 2. Test edge cases in that doc
-      console.log({currentAttempt});
       const data = await pollExamAttempt(url, exam.content_id);
       if (!data) {
         throw new Error('Poll Exam failed to fetch.');

--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -271,8 +271,7 @@ export function pollAttempt(url) {
     }
 
     try {
-      // TODO: make sure sequenceId pulled here is correct both in-exam-sequence and in outline
-      // test w/ timed exam
+      // Why is this undefined in the course view? Let's see how it's called there...
       const { exam } = getState().specialExams;
       const data = await pollExamAttempt(url, exam.content_id);
       if (!data) {

--- a/src/timer/TimerProvider.jsx
+++ b/src/timer/TimerProvider.jsx
@@ -95,15 +95,20 @@ const TimerProvider = ({
     timeLimitMins,
   ]);
 
+  // Set deadline as a reference to timerEnds that updates when it changes
+  const deadline = useRef(new Date(timerEnds));
+  useEffect(() => {
+    deadline.current = new Date(timerEnds);
+  }, [timerEnds]);
+
   useEffect(() => {
     const timerRef = { current: true };
     let timerTick = -1;
-    const deadline = new Date(timerEnds);
 
     const ticker = () => {
       timerTick++;
       const now = Date.now();
-      const remainingTime = (deadline.getTime() - now) / 1000;
+      const remainingTime = (deadline.current.getTime() - now) / 1000;
       const secondsLeft = Math.floor(remainingTime);
 
       setTimeState(getFormattedRemainingTime(secondsLeft));
@@ -142,7 +147,7 @@ const TimerProvider = ({
       clearInterval(timerRef.current);
       timerRef.current = null;
     };
-  }, [ // eslint-disable-line react-hooks/exhaustive-deps
+  }, [
     pingInterval,
     workerUrl,
     processTimeLeft,

--- a/src/timer/TimerProvider.jsx
+++ b/src/timer/TimerProvider.jsx
@@ -142,8 +142,7 @@ const TimerProvider = ({
       clearInterval(timerRef.current);
       timerRef.current = null;
     };
-  }, [
-    timerEnds,
+  }, [ // eslint-disable-line react-hooks/exhaustive-deps
     pingInterval,
     workerUrl,
     processTimeLeft,


### PR DESCRIPTION
Re-fix for: https://2u-internal.atlassian.net/browse/COSMO-125

- Combined fetchActiveAttempt &  fetchLatestExamAttempt into one function with an optional "sequenceId" variable. At the very least, this works without causing errors in non-exam-sequence views. Since the sequenceId is undefined in that case, due to the sequenceId needing to be extracted from the sequence page itself, we can at least still get the latest exam attempt data.

- To my best knowledge, we originally called for the attempt of an exam with a given sequenceId in order to get the latest attempt for an exam regardless of whether or not its active, such that the timer can be seen on non exam-sequence pages. However, we don't truly need the sequence_id for this.

- It's also possible that this was also designed this way so that we could make sure a learner hadn't started two exams at once, and so their "latest exam attempt" would pretain to the exam they started most recently. We already have safeguards for this in edx_exams (See: https://github.com/edx/edx-exams/blob/main/edx_exams/apps/core/api.py#L201).

EDIT: I have not updated my tests yet because I want to make sure this approach is good first