### PR TITLE
fix: correct exam entry check not called

### DIFF
--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -284,8 +284,9 @@ export function pollAttempt(url) {
       dispatch(setActiveAttempt({
         activeAttempt: updatedAttempt,
       }));
-      if (data.status === ExamStatus.SUBMITTED) {
+      if ([ExamStatus.SUBMITTED, ExamStatus.ERROR].includes(data.status)) {
         dispatch(expireExamAttempt());
+        updateAttemptAfter(exam.course_id, exam.content_id)(dispatch);
       }
     } catch (error) {
       handleAPIError(error, dispatch);

--- a/src/exam/ExamWrapper.jsx
+++ b/src/exam/ExamWrapper.jsx
@@ -28,8 +28,8 @@ const ExamWrapper = ({ children, ...props }) => {
 
   const loadInitialData = async () => {
     await dispatch(getExamAttemptsData(courseId, sequence.id));
-    await getAllowProctoringOptOut(sequence.allowProctoringOptOut);
-    await checkExamEntry();
+    await dispatch(getAllowProctoringOptOut(sequence.allowProctoringOptOut));
+    await dispatch(checkExamEntry());
   };
 
   const isGated = sequence && sequence.gatedContent !== undefined && sequence.gatedContent.gated;


### PR DESCRIPTION
1. Resolved issue where the exam entry check for the Proctoring software was not being executed. Seems like we missed a dispatch() call here when doing some redux refactoring a few months ago and this broke.
2. Fixes an edge case where if the backend moves to a terminated state in a way that isn't caused by a client error the frontend does not show the correct interstitial message.

2U-internal Issue: [COSMO-291](https://2u-internal.atlassian.net/browse/COSMO-291)