### PR TITLE
fix: null checking issue in exam entry

### DIFF
--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -560,9 +560,8 @@ export function checkExamEntry() {
           setTimeout(() => reject(), EXAM_START_TIMEOUT_MILLISECONDS);
         }),
       ]).catch(() => {
-        const useLegacyAttemptAPI = exam.attempt.use_legacy_attempt_api;
         dispatch(setApiError({ errorMsg: 'Something has gone wrong with your exam. Proctoring application not detected.' }));
-        updateAttemptAfter(exam.course_id, exam.content_id, endExamWithFailure(exam.attempt.attempt_id, 'exam reentry disallowed', useLegacyAttemptAPI))(dispatch);
+        updateAttemptAfter(exam.course_id, exam.content_id, endExamWithFailure(exam.attempt.attempt_id, 'exam reentry disallowed', false))(dispatch);
       });
     }
   };

--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -546,7 +546,6 @@ export function getAllowProctoringOptOut(allowProctoringOptOut) {
 export function checkExamEntry() {
   return async (dispatch, getState) => {
     const { exam } = getState().specialExams;
-    const useLegacyAttemptAPI = exam.attempt.use_legacy_attempt_api;
     // Check only applies to LTI exams
     if (
       !exam?.attempt
@@ -561,6 +560,7 @@ export function checkExamEntry() {
           setTimeout(() => reject(), EXAM_START_TIMEOUT_MILLISECONDS);
         }),
       ]).catch(() => {
+        const useLegacyAttemptAPI = exam.attempt.use_legacy_attempt_api;
         dispatch(setApiError({ errorMsg: 'Something has gone wrong with your exam. Proctoring application not detected.' }));
         updateAttemptAfter(exam.course_id, exam.content_id, endExamWithFailure(exam.attempt.attempt_id, 'exam reentry disallowed', useLegacyAttemptAPI))(dispatch);
       });


### PR DESCRIPTION
Hidden code issue uncovered by #147 

This will error if the learner has no attempts on the exam section. ~I moved this line to a point where we've already checked that an exam attempt exists.~ Actually this is already checked earlier in the function, the value would always be false.