### PR TITLE
Remove retry button in LTI Proctorio exams

### DIFF
--- a/src/instructions/Instructions.test.jsx
+++ b/src/instructions/Instructions.test.jsx
@@ -502,7 +502,7 @@ describe('SequenceExamWrapper', () => {
     expect(screen.getByTestId('retry-exam-button')).toHaveTextContent('Retry my exam');
   });
 
-  it('Shows submitted practice exam instructions if exam is onboarding and attempt status is submitted', () => {
+  it('Shows submitted practice exam instructions if exam is onboarding and attempt status is submitted on legacy LTI exams', () => {
     store.getState = () => ({
       specialExams: Factory.build('specialExams', {
         activeAttempt: {},
@@ -510,6 +510,7 @@ describe('SequenceExamWrapper', () => {
           is_proctored: true,
           type: ExamType.PRACTICE,
           attempt: Factory.build('attempt', {
+            use_legacy_attempt_api: true,
             attempt_status: ExamStatus.SUBMITTED,
           }),
         }),

--- a/src/instructions/practice_exam/SubmittedPracticeExamInstructions.jsx
+++ b/src/instructions/practice_exam/SubmittedPracticeExamInstructions.jsx
@@ -4,12 +4,17 @@ import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import { Button } from '@openedx/paragon';
 
 import { resetExam } from '../../data';
+import { ExamStatus } from '../../constants';
 
 const SubmittedPracticeExamInstructions = () => {
   const dispatch = useDispatch();
   const { exam } = useSelector(state => state.specialExams);
 
-  const examHasLtiProvider = !exam?.attempt?.use_legacy_attempt_api;
+  // It does not show the reload button if the exam is submitted and not legacy
+  const showRetryButton = !(
+    exam.attempt?.attempt_status === ExamStatus.SUBMITTED
+    && !exam.attempt?.use_legacy_attempt_api
+  );
 
   return (
     <div>
@@ -26,7 +31,7 @@ const SubmittedPracticeExamInstructions = () => {
           + 'completed this practice exam and can continue with your course work.'}
         />
       </p>
-      {!examHasLtiProvider ? (
+      {showRetryButton ? (
         <Button
           data-testid="retry-exam-button"
           variant="primary"

--- a/src/instructions/practice_exam/SubmittedPracticeExamInstructions.jsx
+++ b/src/instructions/practice_exam/SubmittedPracticeExamInstructions.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import { Button } from '@openedx/paragon';
 
@@ -7,6 +7,9 @@ import { resetExam } from '../../data';
 
 const SubmittedPracticeExamInstructions = () => {
   const dispatch = useDispatch();
+  const { exam } = useSelector(state => state.specialExams);
+
+  const examHasLtiProvider = !exam?.attempt?.use_legacy_attempt_api;
 
   return (
     <div>
@@ -23,16 +26,18 @@ const SubmittedPracticeExamInstructions = () => {
           + 'completed this practice exam and can continue with your course work.'}
         />
       </p>
-      <Button
-        data-testid="retry-exam-button"
-        variant="primary"
-        onClick={() => dispatch(resetExam())}
-      >
-        <FormattedMessage
-          id="exam.SubmittedPracticeExamInstructions.retryExamButton"
-          defaultMessage="Retry my exam"
-        />
-      </Button>
+      {!examHasLtiProvider ? (
+        <Button
+          data-testid="retry-exam-button"
+          variant="primary"
+          onClick={() => dispatch(resetExam())}
+        >
+          <FormattedMessage
+            id="exam.SubmittedPracticeExamInstructions.retryExamButton"
+            defaultMessage="Retry my exam"
+          />
+        </Button>
+      ) : null}
     </div>
   );
 };

--- a/src/instructions/practice_exam/SubmittedPracticeExamInstructions.test.jsx
+++ b/src/instructions/practice_exam/SubmittedPracticeExamInstructions.test.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { Factory } from 'rosie';
 import { SubmittedPracticeExamInstructions } from './index';
 import {
   render, screen, initializeTestStore, fireEvent,
 } from '../../setupTest';
+import { ExamStatus, ExamType } from '../../constants';
 
 const mockresetReturn = {};
 const mockDispatch = jest.fn();
@@ -22,15 +24,15 @@ describe('ExamTimerBlock', () => {
     jest.resetAllMocks();
   });
 
-  describe('when no LTI provider is used', () => {
+  describe('when the exam is not proctored', () => {
     beforeEach(() => {
       const preloadedState = {
         specialExams: {
-          exam: {
-            attempt: {
-              use_legacy_attempt_api: true,
-            },
-          },
+          exam: Factory.build('exam', {
+            is_proctored: false,
+            type: ExamType.ONBOARDING,
+            attempt: Factory.build('attempt'),
+          }),
         },
       };
       initializeTestStore(preloadedState);
@@ -59,11 +61,134 @@ describe('ExamTimerBlock', () => {
     });
   });
 
-  describe('when an LTI provider is used', () => {
+  describe('when the exam is not proctored', () => {
     beforeEach(() => {
       const preloadedState = {
         specialExams: {
-          exam: {},
+          exam: Factory.build('exam', {
+            is_proctored: false,
+            type: ExamType.ONBOARDING,
+            attempt: Factory.build('attempt'),
+          }),
+        },
+      };
+      initializeTestStore(preloadedState);
+
+      render(
+        <SubmittedPracticeExamInstructions />,
+      );
+    });
+
+    it('renders the component correctly', async () => {
+      expect(screen.getByText('You have submitted this practice proctored exam')).toBeInTheDocument();
+      expect(screen.getByText(
+        'Practice exams do not affect your grade. You have '
+        + 'completed this practice exam and can continue with your course work.',
+      )).toBeInTheDocument();
+      expect(screen.queryByTestId('retry-exam-button')).toBeInTheDocument();
+    });
+
+    it('calls resetExam() when clicking the retry button', () => {
+      expect(mockDispatch).not.toHaveBeenCalled();
+
+      fireEvent.click(screen.getByTestId('retry-exam-button'));
+
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
+      expect(mockDispatch).toHaveBeenCalledWith(mockresetReturn);
+    });
+  });
+
+  describe('when a legacy proctoring attempt API is used', () => {
+    beforeEach(() => {
+      const preloadedState = {
+        specialExams: {
+          exam: Factory.build('exam', {
+            is_proctored: true,
+            type: ExamType.PROCTORED,
+            attempt: Factory.build('attempt', {
+              use_legacy_attempt_api: true,
+            }),
+          }),
+        },
+      };
+      initializeTestStore(preloadedState);
+
+      render(
+        <SubmittedPracticeExamInstructions />,
+      );
+    });
+
+    it('renders the component correctly', async () => {
+      expect(screen.getByText('You have submitted this practice proctored exam')).toBeInTheDocument();
+      expect(screen.getByText(
+        'Practice exams do not affect your grade. You have '
+        + 'completed this practice exam and can continue with your course work.',
+      )).toBeInTheDocument();
+      expect(screen.queryByTestId('retry-exam-button')).toBeInTheDocument();
+    });
+
+    it('calls resetExam() when clicking the retry button', () => {
+      expect(mockDispatch).not.toHaveBeenCalled();
+
+      fireEvent.click(screen.getByTestId('retry-exam-button'));
+
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
+      expect(mockDispatch).toHaveBeenCalledWith(mockresetReturn);
+    });
+  });
+
+  describe('when an LTI provider is used but it has an error', () => {
+    beforeEach(() => {
+      const preloadedState = {
+        specialExams: {
+          exam: Factory.build('exam', {
+            is_proctored: true,
+            type: ExamType.PROCTORED,
+            attempt: Factory.build('attempt', {
+              use_legacy_attempt_api: false,
+              attempt_status: ExamStatus.ERROR,
+            }),
+          }),
+        },
+      };
+      initializeTestStore(preloadedState);
+
+      render(
+        <SubmittedPracticeExamInstructions />,
+      );
+    });
+
+    it('renders the component correctly', async () => {
+      expect(screen.getByText('You have submitted this practice proctored exam')).toBeInTheDocument();
+      expect(screen.getByText(
+        'Practice exams do not affect your grade. You have '
+        + 'completed this practice exam and can continue with your course work.',
+      )).toBeInTheDocument();
+      expect(screen.queryByTestId('retry-exam-button')).toBeInTheDocument();
+    });
+
+    it('calls resetExam() when clicking the retry button', () => {
+      expect(mockDispatch).not.toHaveBeenCalled();
+
+      fireEvent.click(screen.getByTestId('retry-exam-button'));
+
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
+      expect(mockDispatch).toHaveBeenCalledWith(mockresetReturn);
+    });
+  });
+
+  describe('when an LTI provider is used and the exam is submitted', () => {
+    beforeEach(() => {
+      const preloadedState = {
+        specialExams: {
+          exam: Factory.build('exam', {
+            is_proctored: true,
+            type: ExamType.PROCTORED,
+            attempt: Factory.build('attempt', {
+              use_legacy_attempt_api: false,
+              attempt_status: ExamStatus.SUBMITTED,
+            }),
+          }),
         },
       };
       initializeTestStore(preloadedState);

--- a/src/instructions/practice_exam/SubmittedPracticeExamInstructions.test.jsx
+++ b/src/instructions/practice_exam/SubmittedPracticeExamInstructions.test.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { SubmittedPracticeExamInstructions } from './index';
+import {
+  render, screen, initializeTestStore, fireEvent,
+} from '../../setupTest';
+
+const mockresetReturn = {};
+const mockDispatch = jest.fn();
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => mockDispatch,
+}));
+
+jest.mock('../../data', () => ({
+  ...jest.requireActual('../../data'),
+  resetExam: () => mockresetReturn,
+}));
+
+describe('ExamTimerBlock', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('when no LTI provider is used', () => {
+    beforeEach(() => {
+      const preloadedState = {
+        specialExams: {
+          exam: {
+            attempt: {
+              use_legacy_attempt_api: true,
+            },
+          },
+        },
+      };
+      initializeTestStore(preloadedState);
+
+      render(
+        <SubmittedPracticeExamInstructions />,
+      );
+    });
+
+    it('renders the component correctly', async () => {
+      expect(screen.getByText('You have submitted this practice proctored exam')).toBeInTheDocument();
+      expect(screen.getByText(
+        'Practice exams do not affect your grade. You have '
+        + 'completed this practice exam and can continue with your course work.',
+      )).toBeInTheDocument();
+      expect(screen.queryByTestId('retry-exam-button')).toBeInTheDocument();
+    });
+
+    it('calls resetExam() when clicking the retry button', () => {
+      expect(mockDispatch).not.toHaveBeenCalled();
+
+      fireEvent.click(screen.getByTestId('retry-exam-button'));
+
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
+      expect(mockDispatch).toHaveBeenCalledWith(mockresetReturn);
+    });
+  });
+
+  describe('when an LTI provider is used', () => {
+    beforeEach(() => {
+      const preloadedState = {
+        specialExams: {
+          exam: {},
+        },
+      };
+      initializeTestStore(preloadedState);
+
+      render(
+        <SubmittedPracticeExamInstructions />,
+      );
+    });
+
+    it('doesn\'t show the button if it has an LTI provider', async () => {
+      expect(screen.getByText('You have submitted this practice proctored exam')).toBeInTheDocument();
+      expect(screen.getByText(
+        'Practice exams do not affect your grade. You have '
+        + 'completed this practice exam and can continue with your course work.',
+      )).toBeInTheDocument();
+      expect(screen.queryByTestId('retry-exam-button')).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Description
Ticket: [COSMO-512 🔒](https://2u-internal.atlassian.net/browse/COSMO-512)

After submitting a Practice Proctoring exam there's a "Retry my exam" that if clicked throws an Axios 400 error:
![Screenshot 2024-10-09 at 11 14 47](https://github.com/user-attachments/assets/ed28eaaa-ee0a-4654-8189-3f896edc2dbf)

A Practice Proctoring exam that has an LTI provider cannot be retried. This update removes the button on such cases.