### PR TITLE
Label correction on test

### DIFF
--- a/src/instructions/Instructions.test.jsx
+++ b/src/instructions/Instructions.test.jsx
@@ -502,7 +502,7 @@ describe('SequenceExamWrapper', () => {
     expect(screen.getByTestId('retry-exam-button')).toHaveTextContent('Retry my exam');
   });
 
-  it('Shows submitted practice exam instructions if exam is onboarding and attempt status is submitted on legacy LTI exams', () => {
+  it('Shows submitted practice exam instructions if exam is onboarding and attempt status is submitted on legacy proctored exams', () => {
     store.getState = () => ({
       specialExams: Factory.build('specialExams', {
         activeAttempt: {},


### PR DESCRIPTION
Addressing a [comment that I forgot on a previous PR](https://github.com/openedx/frontend-lib-special-exams/pull/155#discussion_r1794129861). I've used the expression "legacy LTI exams" when it was meant to be "legacy proctoring exams".