### PR TITLE
chore: add logError for js worker call failures

### DIFF
--- a/src/data/messages/handlers.js
+++ b/src/data/messages/handlers.js
@@ -1,3 +1,4 @@
+import { logError } from '@edx/frontend-platform/logging';
 import actionToMessageTypesMap from './constants';
 
 function createWorker(url) {
@@ -26,6 +27,7 @@ export function workerPromiseForEventNames(eventNames, workerUrl) {
           resolve();
         } else {
           reject(e.data.error);
+          logError('workerPromiseForEventNames failed with the following error:', e.data.error);
         }
       };
       proctoringBackendWorker.addEventListener('message', responseHandler);


### PR DESCRIPTION
TICKET: https://2u-internal.atlassian.net/browse/COSMO-637

Adds a "logError" that we will use to track failures when making request to the JS Worker for proctoring (i.e. with the Proctortrack software, as that's the only proctoring provider we use a JS Worker with).