### PR TITLE
fix: ensure full-height layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,7 @@
       "main"
     ]
   },
-  "exports": {
-    "import": "./dist/index.js"
-  },
+
   "repository": {
     "type": "git",
     "url": "git+https://github.com/edx/frontend-lib-special-exams.git"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
       "main"
     ]
   },
-
+  "exports": {
+    "import": "./dist/index.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/edx/frontend-lib-special-exams.git"

--- a/src/exam/Exam.jsx
+++ b/src/exam/Exam.jsx
@@ -95,7 +95,7 @@ const Exam = ({
   const sequenceContent = <>{children}</>;
 
   return (
-    <div className="d-flex flex-column flex-grow-1 justify-content-center">
+    <>
       {shouldShowMasqueradeAlert() && (
         <Alert variant="info" icon={Info} data-testid="masquerade-alert">
           <FormattedMessage
@@ -113,7 +113,7 @@ const Exam = ({
       {isTimeLimited && !originalUserIsStaff && !isGated
         ? <Instructions>{sequenceContent}</Instructions>
         : sequenceContent}
-    </div>
+    </>
   );
 };
 

--- a/src/exam/Exam.jsx
+++ b/src/exam/Exam.jsx
@@ -95,7 +95,7 @@ const Exam = ({
   const sequenceContent = <>{children}</>;
 
   return (
-    <div className="d-flex flex-column justify-content-center">
+    <div className="d-flex flex-column flex-grow-1 justify-content-center">
       {shouldShowMasqueradeAlert() && (
         <Alert variant="info" icon={Info} data-testid="masquerade-alert">
           <FormattedMessage


### PR DESCRIPTION
Fixes https://github.com/openedx/frontend-app-learning/issues/1695
Related PR: https://github.com/openedx/frontend-app-learning/pull/1724

This PR simply moves `<div className="d-flex flex-column justify-content-center"> ` from the Exam component. to the learning MFE.

Summary:
When content within a sequence is shorter than the height of the browser viewport, the .sequence-container > .outline-sidebar-wrapper element does not expand appropriately. This causes the course outline sidebar to be partially or completely hidden from view.

Steps to Reproduce:

Open a course sequence that contains very little content (e.g., a short paragraph or notice).

View the course in a tall browser window.

Observe that the sidebar navigation is cut off or hidden.

Expected Behavior:
The sidebar should remain fully visible and accessible, regardless of the amount of content in the main pane.

Actual Behavior:
When the content is short, the parent container height collapses to fit that content, which in turn restricts the sidebar’s height, hiding part of the navigation.

Screenshots:
![image](https://github.com/user-attachments/assets/e2f1524a-7000-422f-b595-e3a5c40da310)

![image](https://github.com/user-attachments/assets/818c79d4-60d5-4464-8dd4-4d50c326a188)


Demo of fix:
https://github.com/user-attachments/assets/69ce8dae-e73b-487c-bc6a-862701b1ce8d


I think we should have a discussion about removing these wrapper divs entirely so that the layout can handle all the UI