### PR TITLE
Replace injectIntl with the useIntl() hook

### DIFF
--- a/src/exam/Exam.jsx
+++ b/src/exam/Exam.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape, FormattedMessage } from '@edx/frontend-platform/i18n';
+import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
 import { Alert, Spinner } from '@openedx/paragon';
 import { Info } from '@openedx/paragon/icons';
 import { ExamTimerBlock } from '../timer';
@@ -21,12 +21,13 @@ import { getProctoringSettings } from '../data';
  * @constructor
  */
 const Exam = ({
-  isGated, isTimeLimited, originalUserIsStaff, canAccessProctoredExams, children, intl,
+  isGated, isTimeLimited, originalUserIsStaff, canAccessProctoredExams, children,
 }) => {
   const {
     isLoading, activeAttempt, exam, apiErrorMsg,
   } = useSelector(state => state.specialExams);
   const dispatch = useDispatch();
+  const intl = useIntl();
 
   const showTimer = !!(activeAttempt && IS_STARTED_STATUS(activeAttempt.attempt_status));
 
@@ -123,11 +124,10 @@ Exam.propTypes = {
   originalUserIsStaff: PropTypes.bool.isRequired,
   canAccessProctoredExams: PropTypes.bool,
   children: PropTypes.element.isRequired,
-  intl: intlShape.isRequired,
 };
 
 Exam.defaultProps = {
   canAccessProctoredExams: true,
 };
 
-export default injectIntl(Exam);
+export default Exam;

--- a/src/exam/ExamAPIError.jsx
+++ b/src/exam/ExamAPIError.jsx
@@ -3,13 +3,14 @@ import { useSelector } from 'react-redux';
 import { getConfig } from '@edx/frontend-platform';
 import { Alert, Hyperlink, Icon } from '@openedx/paragon';
 import { Info } from '@openedx/paragon/icons';
-import { injectIntl, intlShape, FormattedMessage } from '@edx/frontend-platform/i18n';
+import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
 import messages from './messages';
 
-const ExamAPIError = ({ intl }) => {
+const ExamAPIError = () => {
   const { SITE_NAME, SUPPORT_URL } = getConfig();
   const { apiErrorMsg } = useSelector(state => state.specialExams);
   const shouldShowApiErrorMsg = !!apiErrorMsg && !apiErrorMsg.includes('<');
+  const intl = useIntl();
 
   return (
     <Alert variant="danger" data-testid="exam-api-error-component">
@@ -43,8 +44,4 @@ const ExamAPIError = ({ intl }) => {
   );
 };
 
-ExamAPIError.propTypes = {
-  intl: intlShape.isRequired,
-};
-
-export default injectIntl(ExamAPIError);
+export default ExamAPIError;

--- a/src/instructions/proctored_exam/download-instructions/index.jsx
+++ b/src/instructions/proctored_exam/download-instructions/index.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { getConfig } from '@edx/frontend-platform';
-import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import { Container } from '@openedx/paragon';
 import { ExamStatus } from '../../../constants';
 import { getExamAttemptsData } from '../../../data';
@@ -16,7 +16,7 @@ import DownloadButtons from './DownloadButtons';
 import Footer from '../Footer';
 import SkipProctoredExamButton from '../SkipProctoredExamButton';
 
-const DownloadSoftwareProctoredExamInstructions = ({ intl, skipProctoredExam }) => {
+const DownloadSoftwareProctoredExamInstructions = ({ skipProctoredExam }) => {
   const {
     proctoringSettings,
     exam,
@@ -24,6 +24,8 @@ const DownloadSoftwareProctoredExamInstructions = ({ intl, skipProctoredExam }) 
   } = useSelector(state => state.specialExams);
 
   const dispatch = useDispatch();
+
+  const intl = useIntl();
 
   const {
     attempt,
@@ -162,8 +164,7 @@ const DownloadSoftwareProctoredExamInstructions = ({ intl, skipProctoredExam }) 
 };
 
 DownloadSoftwareProctoredExamInstructions.propTypes = {
-  intl: intlShape.isRequired,
   skipProctoredExam: PropTypes.func.isRequired,
 };
 
-export default injectIntl(DownloadSoftwareProctoredExamInstructions);
+export default DownloadSoftwareProctoredExamInstructions;

--- a/src/timer/CountDownTimer.jsx
+++ b/src/timer/CountDownTimer.jsx
@@ -1,19 +1,20 @@
 import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
 import { Icon, useToggle } from '@openedx/paragon';
 import { Visibility, VisibilityOff } from '@openedx/paragon/icons';
-import { injectIntl } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import { TimerContext } from './TimerProvider';
 import { generateHumanizedTime } from '../helpers';
 
 /**
  * Display timer textual value. Display hide/show button.
  */
-const CountDownTimer = injectIntl((props) => {
+const CountDownTimer = ({ attempt }) => {
   const timer = useContext(TimerContext);
   const timeString = timer.getTimeString();
   const [isShowTimer, showTimer, hideTimer] = useToggle(true);
-  const { intl } = props;
-  const { time_remaining_seconds: timeRemainingSeconds } = props.attempt;
+  const intl = useIntl();
+  const { time_remaining_seconds: timeRemainingSeconds } = attempt;
 
   const generateAccessbilityString = () => {
     const humanizedTime = generateHumanizedTime(timeRemainingSeconds);
@@ -53,6 +54,12 @@ const CountDownTimer = injectIntl((props) => {
       </span>
     </div>
   );
-});
+};
+
+CountDownTimer.propTypes = {
+  attempt: PropTypes.shape({
+    time_remaining_seconds: PropTypes.number.isRequired,
+  }).isRequired,
+};
 
 export default CountDownTimer;

--- a/src/timer/ExamTimerBlock.jsx
+++ b/src/timer/ExamTimerBlock.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { FormattedMessage, injectIntl } from '@edx/frontend-platform/i18n';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import { Button, Alert, useToggle } from '@openedx/paragon';
 import CountDownTimer from './CountDownTimer';
 import { ExamStatus, IS_STARTED_STATUS } from '../constants';
@@ -18,7 +18,8 @@ import {
 /**
  * Exam timer block component.
  */
-const ExamTimerBlock = injectIntl(({ intl }) => {
+const ExamTimerBlock = () => {
+  const intl = useIntl();
   const { activeAttempt: attempt } = useSelector(state => state.specialExams);
   const [isShowMore, showMore, showLess] = useToggle(false);
   const [alertVariant, setAlertVariant] = useState('info');
@@ -43,6 +44,7 @@ const ExamTimerBlock = injectIntl(({ intl }) => {
     }
   };
 
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
     Emitter.once(TIMER_IS_LOW, onLowTime);
     Emitter.once(TIMER_IS_CRITICALLY_LOW, onCriticalLowTime);
@@ -131,8 +133,6 @@ const ExamTimerBlock = injectIntl(({ intl }) => {
       </Alert>
     </TimerProvider>
   );
-});
-
-ExamTimerBlock.propTypes = {};
+};
 
 export default ExamTimerBlock;


### PR DESCRIPTION
### Description
As part of the project for improvements as follow up of react-unit-test-utils, we are going to replace all usages of the deprecated `injectIntl` HOC with the `useIntl()` hook from @edx/frontend-platform/i18n. It is a very straight-forward change, in order to accomplish this we did the following changes:

- In components we have to remove the old `injectIntl`, remove intl as a prop and use the hook instead.
- On `src/timer/ExamTimerBlock.jsx` we got an error related to useEffect to not affect current functionality i just disabled the eslint rule on that line.
- On `src/timer/CountDownTimer.jsx` propTypes were missing so we added it since in this project is not using typescript yet.

#### Support Information
Closes #166 